### PR TITLE
fix: specify the expected client header

### DIFF
--- a/src/colab_cli/client.py
+++ b/src/colab_cli/client.py
@@ -28,8 +28,8 @@ import requests
 # Standard Colab Headers
 ACCEPT_JSON_HEADER = {"key": "Accept", "value": "application/json"}
 COLAB_CLIENT_AGENT_HEADER = {
-    "key": "X-Goog-Colab-Client-Agent",
-    "value": "python-colab-client",
+    "key": "X-Colab-Client-Agent",
+    "value": "colab-cli",
 }
 COLAB_XSRF_TOKEN_HEADER = {"key": "X-Goog-Colab-Token", "value": ""}
 


### PR DESCRIPTION
Where the [mapping happens](http://google3/research/colab/lib/go/clientagent.go;l=24;rcl=914528644) service-side.