### PR TITLE
fix: stop spurious 'drivemount failed' on OAuth waits over 10s

### DIFF
--- a/docs/04_automation_and_utility.md
+++ b/docs/04_automation_and_utility.md
@@ -2,6 +2,7 @@
 log:
 2026-05-07: Added a developer-only `colab whoami` subcommand (hidden from `colab --help`). Mints an access token via the same `auth.get_credentials(...)` path the rest of the CLI uses (honoring the global `--auth=...` flag), refreshes the credentials, then queries `https://oauth2.googleapis.com/tokeninfo` to print the email, scopes, audience, and expiry of whatever the CLI is about to send. Built specifically to short-circuit the "why is my call to colab.pa.googleapis.com 403-ing" debugging loop — the answer is almost always "missing scope" or "wrong identity", both of which `whoami` makes immediately visible. Hidden via `app.command(hidden=True)`; reachable via `colab whoami` or `colab whoami --help`. Suppressed from the daily-update banner check (added to `_AUTO_UPDATE_SUPPRESSED` in `cli.py`) so the banner doesn't obscure the auth output.
 2026-05-11: Removed the local-file update source (`update_file_path` setting and `_fetch_local` helper); `colab update` now consults PyPI only. Switched the default `update_url` to the canonical PyPI JSON API (`https://pypi.org/pypi/google-colab-cli/json`), which already exposes the `info.version` schema the auto-update subsystem expects. Re-added `colab update --install` as a public self-install path that runs `pip install -U google-colab-cli` against the current `sys.executable`; Linux-only (other platforms exit non-zero with an explanatory message), and a silent no-op when the cached `latest_version` is already at or below the current install.
+2026-05-12: Added an optional `timeout=` parameter to `ColabRuntime.execute_code` that flows through to both the `execute()` and `execute_interactive()` branches. `colab auth` and `colab drivemount` now pass `timeout=600` (10 min) via a shared `INTERACTIVE_AUTOMATION_TIMEOUT_SEC` constant in `commands/automation.py`. Background: `jupyter_kernel_client` defaults to a 10s wall-clock timeout that is consumed even when the kernel is idle waiting on `input_request`. With the drivefs hook intercepting that request and prompting the user to OAuth in their browser, any user that takes >10s to click through (essentially everyone) hit `TimeoutError` and saw "drivemount failed" even though the mount had actually succeeded server-side. The fix is scoped narrowly to the two human-in-the-loop subcommands; non-interactive paths (`colab exec`, `colab run`, `colab install`, `colab repl --pipe`, `colab console --pipe`) keep the upstream default since they receive continuous iopub traffic that resets the practical inactivity ceiling.
 ---
 
 # Design: Automation and Utility (`auth`, `install`, `log`, `pay`, `version`, `update`, `whoami`)
@@ -114,6 +115,11 @@ remediation guidance) rather than silently after ~1 minute via the daemon.
     (`/tun/m/credentials-propagation/`), prompts the user with the Google OAuth
     consent URL if needed, and dispatches the required `colab_reply` message to
     the `stdin` channel to unlock the kernel thread.
+-   **Timeout**: The kernel is silent (no iopub traffic) the entire time the
+    user is OAuthing in their browser. To avoid the upstream 10s
+    `jupyter_kernel_client` default raising `TimeoutError` mid-flow, this
+    subcommand passes `timeout=INTERACTIVE_AUTOMATION_TIMEOUT_SEC` (600s) to
+    `ColabRuntime.execute_code`. Same applies to `colab auth`.
 
 ### 4. Logging and Notebook Capture (`colab log`)
 

--- a/src/colab_cli/commands/automation.py
+++ b/src/colab_cli/commands/automation.py
@@ -26,8 +26,22 @@ from colab_cli.auth import get_credentials
 from colab_cli.utils import get_status_code
 
 
+# Default execute() timeout for human-in-the-loop automations (auth /
+# drivemount). The kernel goes silent while the user completes a browser
+# OAuth flow, which can routinely take 30s+; the upstream 10s default
+# raises ``TimeoutError`` mid-flow even though the mount actually succeeds.
+# 10 minutes is long enough for any realistic interactive auth ceremony
+# without leaving CI hangs unbounded.
+INTERACTIVE_AUTOMATION_TIMEOUT_SEC = 600
+
+
 def run_automation(
-    name: str, op: str, code: str, allow_stdin: bool = False, path: str = None
+    name: str,
+    op: str,
+    code: str,
+    allow_stdin: bool = False,
+    path: str = None,
+    timeout: Optional[float] = None,
 ):
     from colab_cli.common import state
 
@@ -130,7 +144,7 @@ def run_automation(
         else:
             state.history.log_event(name, "automation", {"op": op, "code": code})
 
-        outputs = runtime.execute_code(code, allow_stdin=allow_stdin)
+        outputs = runtime.execute_code(code, allow_stdin=allow_stdin, timeout=timeout)
         state.history.log_event(
             name, "automation_result", {"op": op, "outputs": outputs}
         )
@@ -166,7 +180,13 @@ def auth(
     name = state.resolve_session(session)
     code = "import os\nos.environ['USE_AUTH_EPHEM'] = '0'\nfrom google.colab import auth\nauth.authenticate_user()"
     typer.echo(f"[colab] Starting Google Auth flow on {name}...")
-    run_automation(name, "auth", code, allow_stdin=True)
+    run_automation(
+        name,
+        "auth",
+        code,
+        allow_stdin=True,
+        timeout=INTERACTIVE_AUTOMATION_TIMEOUT_SEC,
+    )
 
 
 def drivemount(
@@ -181,7 +201,14 @@ def drivemount(
     name = state.resolve_session(session)
     code = f"from google.colab import drive\ndrive.mount('{path}')"
     typer.echo(f"[colab] Mounting Google Drive to '{path}' on {name}...")
-    run_automation(name, "drivemount", code, allow_stdin=True, path=path)
+    run_automation(
+        name,
+        "drivemount",
+        code,
+        allow_stdin=True,
+        path=path,
+        timeout=INTERACTIVE_AUTOMATION_TIMEOUT_SEC,
+    )
 
 
 def install(

--- a/src/colab_cli/runtime.py
+++ b/src/colab_cli/runtime.py
@@ -161,8 +161,21 @@ class ColabRuntime:
         allow_stdin: bool = False,
         stdin_hook: Any = None,
         output_hook: Optional[Callable[[Dict[str, Any]], None]] = None,
+        timeout: Optional[float] = None,
     ) -> List[Dict[str, Any]]:
+        # ``jupyter_kernel_client`` defaults ``timeout`` to ``REQUEST_TIMEOUT``
+        # (10 seconds) on both ``execute`` and ``execute_interactive``. That
+        # value is a wall-clock budget that shrinks every time the poll loop
+        # iterates -- as long as iopub/stdin events arrive back-to-back the
+        # call survives, but a single >10s quiet stretch (e.g. a kernel
+        # blocked on ``input_request`` while the user OAuths in the browser)
+        # will raise ``TimeoutError`` even though the underlying execution is
+        # still healthy. Callers that know they need a longer ceiling can
+        # pass ``timeout=`` here; otherwise we forward whatever the upstream
+        # default is (currently 10s).
         kwargs = {"allow_stdin": allow_stdin}
+        if timeout is not None:
+            kwargs["timeout"] = timeout
 
         # Wrap stdin_hook to log inputs
         original_stdin_hook = stdin_hook

--- a/tests/test_automation.py
+++ b/tests/test_automation.py
@@ -98,3 +98,28 @@ def test_cli_drivemount(mock_state, mock_runtime_class, mock_session):
 
     assert "drive.mount('/foo/bar')" in called_code
     assert mock_runtime.colab_request_hook is not None
+    # Drivemount waits for the user to OAuth in their browser; the kernel
+    # goes silent during that wait and the default 10s execute() timeout
+    # would raise TimeoutError mid-flow. Insist on a generous timeout
+    # (>= 5 minutes) being forwarded to runtime.execute_code.
+    _, kwargs = mock_runtime.execute_code.call_args
+    assert kwargs.get("timeout") is not None and kwargs["timeout"] >= 300
+
+
+@patch("colab_cli.commands.automation.ColabRuntime")
+@patch("colab_cli.common.state")
+def test_cli_auth_uses_long_timeout(mock_state, mock_runtime_class, mock_session):
+    """`colab auth` walks the user through a paste-the-code flow that
+    routinely takes >10s, so it must pass a generous timeout to
+    runtime.execute_code or the call will TimeoutError mid-flow."""
+    mock_state.store.get.return_value = mock_session
+    mock_state.resolve_session.return_value = "test-session"
+
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = [{"text": "Authenticated"}]
+
+    result = runner.invoke(app, ["auth", "-s", "test-session"])
+    assert result.exit_code == 0
+
+    _, kwargs = mock_runtime.execute_code.call_args
+    assert kwargs.get("timeout") is not None and kwargs["timeout"] >= 300

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -77,6 +77,48 @@ def test_colab_runtime_execute_code():
     }
 
 
+def test_colab_runtime_execute_code_default_no_timeout():
+    """By default, execute_code should NOT pass a timeout (relies on jupyter
+    kernel client default), preserving existing behavior for fast / streaming
+    workloads."""
+    runtime = ColabRuntime("http://url", "token123")
+    mock_kc = MagicMock()
+    runtime._kernel_client = mock_kc
+
+    mock_kc.execute.return_value = {"outputs": []}
+    runtime.execute_code("print(1)")
+
+    _, kwargs = mock_kc.execute.call_args
+    assert "timeout" not in kwargs
+
+
+def test_colab_runtime_execute_code_with_timeout():
+    """When a timeout is supplied, it must be forwarded to kernel_client.execute."""
+    runtime = ColabRuntime("http://url", "token123")
+    mock_kc = MagicMock()
+    runtime._kernel_client = mock_kc
+
+    mock_kc.execute.return_value = {"outputs": []}
+    runtime.execute_code("print(1)", timeout=600)
+
+    _, kwargs = mock_kc.execute.call_args
+    assert kwargs.get("timeout") == 600
+
+
+def test_colab_runtime_execute_interactive_with_timeout():
+    """timeout must also be plumbed through the execute_interactive branch
+    (used when an output_hook is supplied)."""
+    runtime = ColabRuntime("http://url", "token123")
+    mock_kc = MagicMock()
+    runtime._kernel_client = mock_kc
+
+    mock_kc.execute_interactive.return_value = {"content": {"status": "ok"}}
+    runtime.execute_code("print(1)", output_hook=lambda o: None, timeout=600)
+
+    _, kwargs = mock_kc.execute_interactive.call_args
+    assert kwargs.get("timeout") == 600
+
+
 def test_colab_runtime_stop():
     runtime = ColabRuntime("http://url", "token123")
     mock_kc = MagicMock()


### PR DESCRIPTION
The drivefs handshake blocks the kernel on input_request while the user OAuths in their browser. jupyter_kernel_client's default 10s wall-clock timeout fires during this silent stretch, raising TimeoutError mid-flow even though the mount has actually succeeded server-side.

Add an optional timeout= parameter to ColabRuntime.execute_code that is forwarded to both execute() and execute_interactive(). Pass timeout=600 (10 min) from the human-in-the-loop subcommands -- colab drivemount and colab auth -- via a shared INTERACTIVE_AUTOMATION_TIMEOUT_SEC constant. Non-interactive paths keep the upstream default since their continuous iopub traffic never trips the practical inactivity ceiling.