### PR TITLE
Add runtime_version to new command

### DIFF
--- a/src/colab_cli/client.py
+++ b/src/colab_cli/client.py
@@ -75,6 +75,13 @@ def uuid_to_web_safe_base64(uuid_val: uuid.UUID) -> str:
     return transformed + padding
 
 
+class RuntimeVersionLabel(str, Enum):
+    V202604 = "2026.04"
+    V202601 = "2026.01"
+    V202510 = "2025.10"
+    V202507 = "2025.07"
+
+
 class Accelerator(str, Enum):
     NONE = "NONE"
     G4 = "G4"
@@ -240,14 +247,15 @@ class Client:
         notebook_hash: uuid.UUID,
         variant: Optional[Variant] = None,
         accelerator: Optional[Accelerator] = None,
+        runtime_version_label: Optional[RuntimeVersionLabel] = None,
     ) -> Union[PostAssignmentResponse, Assignment]:
-        assignment = self._get_assignment(notebook_hash, variant, accelerator)
+        assignment = self._get_assignment(notebook_hash, variant, accelerator, runtime_version_label)
         if isinstance(assignment, Assignment):
             return assignment
 
         try:
             res = self._post_assignment(
-                notebook_hash, assignment.token, variant, accelerator
+                notebook_hash, assignment.token, variant, accelerator, runtime_version_label
             )
         except ColabRequestError as e:
             if get_status_code(e) == 412:
@@ -261,6 +269,7 @@ class Client:
         notebook_hash: uuid.UUID,
         variant: Optional[Variant] = None,
         accelerator: Optional[Accelerator] = None,
+        runtime_version_label: Optional[RuntimeVersionLabel] = None,
     ) -> str:
         url = urljoin(self.colab_domain, f"{TUN_ENDPOINT}/assign")
         params = {"nbh": uuid_to_web_safe_base64(notebook_hash)}
@@ -268,6 +277,8 @@ class Client:
             params["variant"] = variant.value
         if accelerator:
             params["accelerator"] = accelerator.value
+        if runtime_version_label:
+            params["runtime_version_label"] = runtime_version_label.value
 
         req = requests.Request("GET", url, params=params)
         prep = req.prepare()
@@ -278,8 +289,9 @@ class Client:
         notebook_hash: uuid.UUID,
         variant: Optional[Variant] = None,
         accelerator: Optional[Accelerator] = None,
+        runtime_version_label: Optional[RuntimeVersionLabel] = None,
     ) -> Union[GetAssignmentResponse, Assignment]:
-        url = self._build_assign_url(notebook_hash, variant, accelerator)
+        url = self._build_assign_url(notebook_hash, variant, accelerator, runtime_version_label)
         return self._issue_request(url, schema=Union[GetAssignmentResponse, Assignment])
 
     def _post_assignment(
@@ -288,8 +300,9 @@ class Client:
         xsrf_token: str,
         variant: Optional[Variant] = None,
         accelerator: Optional[Accelerator] = None,
+        runtime_version_label: Optional[RuntimeVersionLabel] = None,
     ) -> PostAssignmentResponse:
-        url = self._build_assign_url(notebook_hash, variant, accelerator)
+        url = self._build_assign_url(notebook_hash, variant, accelerator, runtime_version_label)
         headers = {COLAB_XSRF_TOKEN_HEADER["key"]: xsrf_token}
         return self._issue_request(
             url, method="POST", headers=headers, schema=PostAssignmentResponse

--- a/src/colab_cli/commands/session.py
+++ b/src/colab_cli/commands/session.py
@@ -22,6 +22,7 @@ import typer
 from typing_extensions import Annotated
 
 from colab_cli.client import (
+    RuntimeVersionLabel,
     Accelerator,
     ColabRequestError,
     PostAssignmentResponse,
@@ -129,6 +130,15 @@ def new(
             ),
         ),
     ] = None,
+    runtime_version: Annotated[
+        Optional[str],
+        typer.Option(
+            help=(
+                "Runtime version. Supported: 2026.04, 2026.01, 2025.10, 2025.07."
+                "\n\nIf omitted uses latest version."
+            ),
+        ),
+    ] = None,
 ):
     """Create a new session"""
     from colab_cli.common import state
@@ -150,11 +160,20 @@ def new(
             "g4": Accelerator.G4,
         }
         accelerator = mapping.get(gpu.lower(), Accelerator.A100)
+    
+    if runtime_version:
+        mapping = {
+            "2026.04": RuntimeVersionLabel.V202604,
+            "2026.01": RuntimeVersionLabel.V202601,
+            "2025.10": RuntimeVersionLabel.V202510,
+            "2025.07": RuntimeVersionLabel.V202507,
+        }
+        runtime_version_label = mapping.get(runtime_version)
 
     typer.echo(f"[colab] Creating session '{name}'...")
     try:
         res = state.client.assign(
-            uuid.uuid4(), variant=variant, accelerator=accelerator
+            uuid.uuid4(), variant=variant, accelerator=accelerator, runtime_version_label=runtime_version_label
         )
     except ColabRequestError as e:
         # The Colab backend returns 400 when the caller is not entitled to the


### PR DESCRIPTION
Currently, there is no way to specify the runtime version. This allows the user to spin up a specific runtime version.