### PR TITLE
fix: query installed_version("google-colab-cli") after PyPI rename

### DIFF
--- a/src/colab_cli/auto_update.py
+++ b/src/colab_cli/auto_update.py
@@ -42,7 +42,7 @@ from colab_cli.state import Settings
 def get_app_version() -> str:
     """Return the installed package version, falling back to the git short hash."""
     try:
-        return installed_version("colab")
+        return installed_version("google-colab-cli")
     except (PackageNotFoundError, InvalidVersion):
         pass
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -27,6 +27,10 @@ def test_version_installed():
         result = runner.invoke(app, ["version"])
         assert result.exit_code == 0
         assert "Version: 0.2.0" in result.output
+        # Guard against a silent regression if the PyPI distribution name
+        # changes again: importlib.metadata.version() must be called with
+        # the distribution name exactly as it appears in pyproject.toml.
+        mock_version.assert_called_with("google-colab-cli")
 
 
 def test_version_git_fallback():


### PR DESCRIPTION
## Summary

- One-line fix: `get_app_version()` in `src/colab_cli/auto_update.py` was still calling `importlib.metadata.version("colab")` after the rename in #20 — repoint it to `"google-colab-cli"`.
- Strengthen `test_version_installed` with `mock_version.assert_called_with("google-colab-cli")` so a future rename can't silently regress this again.

## Why

Verified live: after `pip install google-colab-cli` from PyPI (`0.5.4`), `colab version` printed `Version: unknown` instead of `0.5.4`. Root cause: the rename missed this one call site. The lookup raised `PackageNotFoundError`, the function fell through to the git-rev-parse fallback, and inside an install venv (no git repo) that also fails and returns `"unknown"`. The same broken value also flows into the auto-update banner's "current vs latest" comparison, which would mis-trigger.

The existing `tests/test_version.py` tests mock `installed_version` directly without asserting the argument, which is why CI passed for #20 despite the regression — the new `assert_called_with` closes that gap.

## Verification

- `uv run pytest tests/` — 198 passed
- `uv run ruff check .` — clean
- Built a wheel from the fix branch, installed into a fresh venv, ran `colab version`: now prints the package version instead of `"unknown"`. (Dev-suffixed locally because the build was pre-tag; on a tagged build the output is clean.)