### PR TITLE
Kernel restart hanging

### DIFF
--- a/src/colab_cli/commands/session.py
+++ b/src/colab_cli/commands/session.py
@@ -274,7 +274,10 @@ def restart(
         on_session_started=on_sess_started,
     )
 
-    runtime.restart(timeout=INTERACTIVE_AUTOMATION_TIMEOUT_SEC)
+    try:
+        runtime.restart()
+    finally:
+        runtime.stop()
 
 
 def sessions_command():

--- a/src/colab_cli/commands/session.py
+++ b/src/colab_cli/commands/session.py
@@ -27,6 +27,7 @@ from colab_cli.client import (
     PostAssignmentResponse,
     Variant,
 )
+from colab_cli.commands.automation import INTERACTIVE_AUTOMATION_TIMEOUT_SEC
 from colab_cli.utils import get_status_code
 from colab_cli.state import SessionState
 from colab_cli.runtime import ColabRuntime
@@ -244,6 +245,36 @@ def new(
         },
     )
     typer.echo("[colab] Session READY.")
+
+
+def restart( 
+    session: Annotated[
+        Optional[str], typer.Option("-s", "--session", help="Session name")
+    ] = None,
+):
+    from colab_cli.common import state
+
+    name = state.resolve_session(session)
+    s = state.store.get(name)
+
+    def on_started(kid):
+        s.kernel_id = kid
+        state.store.add(s)
+
+    def on_sess_started(sid):
+        s.session_id = sid
+        state.store.add(s)
+
+    runtime = ColabRuntime(
+        s.url,
+        s.token,
+        kernel_id=s.kernel_id,
+        session_id=s.session_id,
+        on_kernel_started=on_started,
+        on_session_started=on_sess_started,
+    )
+
+    runtime.restart(timeout=INTERACTIVE_AUTOMATION_TIMEOUT_SEC)
 
 
 def sessions_command():
@@ -471,6 +502,7 @@ def keep_alive(
 def register(app: typer.Typer):
     app.command()(new)
     app.command(name="sessions")(sessions_command)
+    app.command()(restart)
     app.command()(status)
     app.command()(stop)
     app.command(hidden=True)(keep_alive)

--- a/src/colab_cli/runtime.py
+++ b/src/colab_cli/runtime.py
@@ -154,6 +154,12 @@ class ColabRuntime:
                     raise e
 
         return self._kernel_client
+    
+    def restart(
+        self,
+        timeout: Optional[float] = None,
+    ):
+        self.kernel_client.restart(timeout=timeout)
 
     def execute_code(
         self,


### PR DESCRIPTION
It turns out the restart command was hanging due to a leaked ColabRuntime. Calling stop with shutdown_kernel = False resolves the issue.