### PR TITLE
fix: declare click, typing-extensions, websocket-client as deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "CLI for interacting with Colab."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "click>=8.0",
     "google-auth>=2.49.1",
     "google-auth-oauthlib>=1.3.0",
     "jupyter-kernel-client",
@@ -19,6 +20,8 @@ dependencies = [
     "requests>=2.32.5",
     "rich>=14.3.3",
     "typer>=0.24.1",
+    "typing-extensions>=4.0",
+    "websocket-client>=1.0",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -306,6 +306,7 @@ wheels = [
 name = "google-colab-cli"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "jupyter-kernel-client" },
@@ -320,6 +321,8 @@ dependencies = [
     { name = "requests" },
     { name = "rich" },
     { name = "typer" },
+    { name = "typing-extensions" },
+    { name = "websocket-client" },
 ]
 
 [package.dev-dependencies]
@@ -329,6 +332,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "google-auth", specifier = ">=2.49.1" },
     { name = "google-auth-oauthlib", specifier = ">=1.3.0" },
     { name = "jupyter-kernel-client", git = "https://github.com/googlecolab/jupyter-kernel-client.git" },
@@ -343,6 +347,8 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "typer", specifier = ">=0.24.1" },
+    { name = "typing-extensions", specifier = ">=4.0" },
+    { name = "websocket-client", specifier = ">=1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Three first-party imports were relying on transitive dependencies that no longer resolve when installing from PyPI:

- **`click`** (used by `cli.py` and `commands/files.py`) was being pulled in by older typer versions. typer 0.25.x dropped the explicit click dependency, so a fresh `pip install google-colab-cli==0.5.4` resolves `typer==0.25.1` which does NOT install click, and `colab version` fails immediately with `ModuleNotFoundError: No module named 'click'`.
- **`typing_extensions`** was pulled in transitively by typer/pydantic.
- **`websocket`** (the `websocket-client` package, used by `runtime.py`) was pulled in by `jupyter-kernel-client`.

All three are real first-party dependencies and should be declared.

## Why now

I tested the live `0.5.4` install on PyPI in a clean venv as a sanity check ahead of the first OSS Exit Gate release, and `colab version` crashed on import. This bug exists on `main` today as well (PR #25 only changed `cloudbuild.yaml`).

## Verification

- `uv pip install google-colab-cli==0.5.4` (PyPI):
  ```
  $ colab version
  Traceback (most recent call last):
    ...
  ModuleNotFoundError: No module named 'click'
  ```
- Built a wheel from this branch, installed into a fresh venv:
  ```
  $ colab version
  Version: 0.5.6.dev0+...
  ```
- `uv run pytest tests/` — 198 passed
- `uv run ruff check .` — clean

## Follow-ups (not in this PR)

`pytest`, `pytest-cov`, `pytest-mock` are listed in **runtime** dependencies but should be in the `dev` group — they bloat every install with test machinery users don't need. Worth a separate cleanup PR.