### PR TITLE
build: move pytest/pytest-cov/pytest-mock from runtime deps to dev group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,6 @@ dependencies = [
     "prompt-toolkit>=3.0.52",
     "pydantic>=2.12.5",
     "pygments>=2.19.2",
-    "pytest>=9.0.2",
-    "pytest-cov>=7.0.0",
-    "pytest-mock>=3.15.1",
     "requests>=2.32.5",
     "rich>=14.3.3",
     "typer>=0.24.1",
@@ -48,5 +45,8 @@ jupyter-kernel-client = { git = "https://github.com/googlecolab/jupyter-kernel-c
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.2",
+    "pytest-cov>=7.0.0",
+    "pytest-mock>=3.15.1",
     "ruff>=0.15.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -315,9 +315,6 @@ dependencies = [
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pygments" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
     { name = "requests" },
     { name = "rich" },
     { name = "typer" },
@@ -327,6 +324,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -341,9 +341,6 @@ requires-dist = [
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pygments", specifier = ">=2.19.2" },
-    { name = "pytest", specifier = ">=9.0.2" },
-    { name = "pytest-cov", specifier = ">=7.0.0" },
-    { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "typer", specifier = ">=0.24.1" },
@@ -352,7 +349,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.6" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "ruff", specifier = ">=0.15.6" },
+]
 
 [[package]]
 name = "idna"


### PR DESCRIPTION
## Summary

`pytest`, `pytest-cov`, `pytest-mock` were in `[project].dependencies`, which forced every `pip install google-colab-cli` user to install the entire pytest test framework plus its transitive deps (`coverage`, `iniconfig`, `pluggy`). Move them to `[dependency-groups].dev` (PEP 735) where they belong.

## Concrete impact

Measured by installing the resulting wheel into a fresh py3.13 venv:

| | Before | After | Delta |
|---|---|---|---|
| Packages installed | 57 | 51 | **−6** |
| Install size | 200 MB | 197 MB | **−3 MB** |
| `pytest`, `pytest-cov`, `pytest-mock`, `coverage`, `iniconfig`, `pluggy` | Installed | **Gone** | ✓ |

## Why it matters beyond size

Removing pytest from runtime deps stops dependency scanners (`pipdeptree`, `pip-audit`, dependabot, snyk) from treating pytest version pins as user-facing constraints. Previously, any downstream environment that pinned `pytest 8.x` for plugin compat would conflict with our floor of `pytest>=9.0.2` even though no user code imports pytest.

## What still works

- `uv sync` populates both groups by default, so contributors get pytest automatically — no workflow change.
- `uv run pytest tests/` → 201 passed.
- `uv run ruff check .` → clean.
- Built wheel + installed into fresh venv: no pytest/coverage/pluggy in site-packages, `colab version` works, `colab url` works (also verifies #27's fragment fix is intact in the install path).