### PR TITLE
feat: Add in-place upgrade suggestion to colab update

### DIFF
--- a/docs/04_automation_and_utility.md
+++ b/docs/04_automation_and_utility.md
@@ -1,5 +1,6 @@
 ---
 log:
+2026-06-01: Improved `colab update` output. On Linux platforms, an additional message is shown recommending `colab update --install` to upgrade in place, positioned above the standard `pip`/`uv` installation command.
 2026-05-27: Refactored `colab README` and `colab AGENT` to bundle `README.md` and `AGENTS.md` via Hatchling's `force-include` and read them using `importlib.resources` instead of `importlib.metadata`. `colab AGENT` now correctly prints `AGENTS.md`.
 2026-05-27: Extended `colab update --install` to detect if the CLI was installed via `uv tool install` (by checking if `sys.executable` contains `/uv/`) and if so, use `uv tool install -U google-colab-cli` to upgrade.
 2026-05-27: Updated auto-update upgrade hint to recommend `pip install --upgrade google-colab-cli` instead of `colab`, aligning with the PyPI package name.
@@ -185,8 +186,10 @@ remediation guidance) rather than silently after ~1 minute via the daemon.
             the cache.
 -   **Notification**: If a new version is found, a non-intrusive message is
     printed to the console with a `Run 'pip install --upgrade google-colab-cli' to
-    update.` hint. The cached banner shown between fetches uses the generic
-    `Run 'colab update' to update.` hint.
+    update.` hint. On Linux platforms where `--install` self-update is supported,
+    an additional hint `You can run 'colab update --install' to upgrade in place.`
+    is displayed above the pip/uv install command. The cached banner shown between
+    fetches uses the generic `Run 'colab update' to update.` hint.
 -   **Self-install (`--install`)**: An opt-in `--install` flag (default
     `False`) makes `colab update` upgrade the CLI in place (**Linux only**).
     It detects how the CLI was installed:

--- a/src/colab_cli/auto_update.py
+++ b/src/colab_cli/auto_update.py
@@ -113,6 +113,8 @@ def announce_upgrade(
     typer.echo(
         f"\n[colab] A new version of Colab CLI is available: {latest} (current: {current})"
     )
+    if platform.system() == "Linux" and ("pip" in install_cmd or "uv" in install_cmd):
+        typer.echo("[colab] You can run 'colab update --install' to upgrade in place.")
     typer.echo(f"[colab] Run '{install_cmd}' to update.")
     if show_disable_hint:
         typer.echo(

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -129,7 +129,16 @@ def test_pypi_upgrade_uses_pip_hint(mocker, app_version, fake_settings, mock_pyp
     result = runner.invoke(app, ["update"])
     assert result.exit_code == 0
     assert "available: 1.1.0 (current: 1.0.0)" in result.output
+    assert "You can run 'colab update --install' to upgrade in place." in result.output
     assert "Run 'pip install --upgrade google-colab-cli' to update." in result.output
+
+    idx_install = result.output.find(
+        "You can run 'colab update --install' to upgrade in place."
+    )
+    idx_pip = result.output.find(
+        "Run 'pip install --upgrade google-colab-cli' to update."
+    )
+    assert idx_install < idx_pip
 
 
 def test_pypi_upgrade_uses_uv_hint(mocker, app_version, fake_settings, mock_pypi):
@@ -144,7 +153,32 @@ def test_pypi_upgrade_uses_uv_hint(mocker, app_version, fake_settings, mock_pypi
     result = runner.invoke(app, ["update"])
     assert result.exit_code == 0
     assert "available: 1.1.0 (current: 1.0.0)" in result.output
+    assert "You can run 'colab update --install' to upgrade in place." in result.output
     assert "Run 'uv tool install -U google-colab-cli' to update." in result.output
+
+    idx_install = result.output.find(
+        "You can run 'colab update --install' to upgrade in place."
+    )
+    idx_uv = result.output.find("Run 'uv tool install -U google-colab-cli' to update.")
+    assert idx_install < idx_uv
+
+
+def test_pypi_upgrade_uses_pip_hint_non_linux(
+    mocker, app_version, fake_settings, mock_pypi
+):
+    app_version("1.0.0")
+    mock_pypi({"info": {"version": "1.1.0"}})
+    fake_settings()
+    mocker.patch("sys.executable", "/usr/bin/python")
+    mocker.patch("colab_cli.auto_update.platform.system", return_value="Darwin")
+
+    result = runner.invoke(app, ["update"])
+    assert result.exit_code == 0
+    assert "available: 1.1.0 (current: 1.0.0)" in result.output
+    assert (
+        "You can run 'colab update --install' to upgrade in place." not in result.output
+    )
+    assert "Run 'pip install --upgrade google-colab-cli' to update." in result.output
 
 
 def test_explicit_update_omits_disable_hint(app_version, fake_settings, mock_pypi):


### PR DESCRIPTION
print an additional hint suggesting `colab update --install` when supported.