### PR TITLE
feat: Expose --timeout flag for exec and run commands

### DIFF
--- a/docs/02_execution_and_interactive.md
+++ b/docs/02_execution_and_interactive.md
@@ -26,6 +26,7 @@ Execution involves sending Python code (or shell commands) to the Jupyter kernel
     - If file path is local: Read content, send as code.
     - If file path is remote: Execute `!python <path>`.
 - **Multi-Modal Output**: Handle `display_data` messages (e.g., `image/png`, `text/html`). For the CLI, we'll save images to temporary files and print their paths, or if the terminal supports it (e.g., iTerm2), inline them.
+- **Timeout Configuration**: Exposes a `--timeout` flag (default 10s) to allow long-running silent tasks (like model compilation or data downloading) to execute without being prematurely killed.
 
 ### 3. Console (`colab console`)
 - **Implementation**: Connects directly to the backend terminal endpoint (`/colab/tty`) via WebSockets using `websocket-client`.

--- a/docs/05_run_command.md
+++ b/docs/05_run_command.md
@@ -29,6 +29,7 @@ colab run [OPTIONS] SCRIPT [SCRIPT_ARGS]...
 | `--gpu` | str | None | Same set as `colab new --gpu` (T4, L4, G4, H100, A100). |
 | `--tpu` | str | None | Same set as `colab new --tpu` (v5e1, v6e1). |
 | `--keep` | bool | False | Do **not** stop the session after the script finishes. |
+| `--timeout` | float | 10.0 | Timeout in seconds for code execution to prevent hanging on silent tasks. |
 
 ### Shebang usage
 With `--keep` and `--gpu` baked into the shebang line, an entire one-file workload becomes:

--- a/src/colab_cli/commands/execution.py
+++ b/src/colab_cli/commands/execution.py
@@ -108,6 +108,9 @@ def exec_command(
     output_image: Annotated[
         Optional[str], typer.Option("--output-image", help="Path to save plot")
     ] = None,
+    timeout: Annotated[
+        Optional[float], typer.Option("--timeout", help="Timeout in seconds for code execution (default: 10s)")
+    ] = None,
 ):
     """Execute code in a session"""
     from colab_cli.common import state
@@ -205,7 +208,9 @@ def exec_command(
             state.store.add(s)
 
             outputs = runtime.execute_code(
-                code, output_hook=lambda o: display_output(o, output_image)
+                code, 
+                output_hook=lambda o: display_output(o, output_image),
+                timeout=timeout
             )
             if "cell" in block:
                 save_output(outputs, block["cell"])

--- a/src/colab_cli/commands/execution.py
+++ b/src/colab_cli/commands/execution.py
@@ -109,8 +109,8 @@ def exec_command(
         Optional[str], typer.Option("--output-image", help="Path to save plot")
     ] = None,
     timeout: Annotated[
-        Optional[float], typer.Option("--timeout", help="Timeout in seconds for code execution (default: 10s)")
-    ] = None,
+        Optional[float], typer.Option("--timeout", help="Timeout in seconds for code execution")
+    ] = 10.0,
 ):
     """Execute code in a session"""
     from colab_cli.common import state

--- a/src/colab_cli/commands/run.py
+++ b/src/colab_cli/commands/run.py
@@ -234,8 +234,8 @@ def run_command(
         ),
     ] = False,
     timeout: Annotated[
-        Optional[float], typer.Option("--timeout", help="Timeout in seconds for code execution (default: 10s)")
-    ] = None,
+        Optional[float], typer.Option("--timeout", help="Timeout in seconds for code execution")
+    ] = 10.0,
 ):
     """Run a Python script on a fresh Colab VM, then release the VM
 

--- a/src/colab_cli/commands/run.py
+++ b/src/colab_cli/commands/run.py
@@ -233,6 +233,9 @@ def run_command(
             ),
         ),
     ] = False,
+    timeout: Annotated[
+        Optional[float], typer.Option("--timeout", help="Timeout in seconds for code execution (default: 10s)")
+    ] = None,
 ):
     """Run a Python script on a fresh Colab VM, then release the VM
 
@@ -386,7 +389,11 @@ def run_command(
         state.store.add(s)
 
         try:
-            outputs = runtime.execute_code(payload, output_hook=_make_run_output_hook())
+            outputs = runtime.execute_code(
+                payload, 
+                output_hook=_make_run_output_hook(),
+                timeout=timeout
+            )
         except Exception:
             # Genuine transport-level failure. Cleanup still happens via the
             # outer finally; surface non-zero exit so callers/CI notice.

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -58,7 +58,7 @@ def test_cli_exec_file(mock_store, mock_runtime_class, mock_common_state, tmp_pa
     mock_runtime.execute_code.assert_any_call(
         "import os; os.makedirs('/content', exist_ok=True); os.chdir('/content')"
     )
-    mock_runtime.execute_code.assert_any_call("print('hello')", output_hook=ANY)
+    mock_runtime.execute_code.assert_any_call("print('hello')", output_hook=ANY, timeout=None)
 
 
 def test_cli_exec_stdin(mock_store, mock_runtime_class, mock_common_state):
@@ -80,7 +80,7 @@ def test_cli_exec_stdin(mock_store, mock_runtime_class, mock_common_state):
     assert mock_session.last_execution[1] is None
     assert mock_session.last_execution[2] is not None
     mock_store.add.assert_called_with(mock_session)
-    mock_runtime.execute_code.assert_any_call("print(42)", output_hook=ANY)
+    mock_runtime.execute_code.assert_any_call("print(42)", output_hook=ANY, timeout=None)
 
 
 def test_cli_exec_not_found(mock_common_state):
@@ -176,3 +176,24 @@ def test_cli_exec_lost_session_prunes(
     assert result.exit_code == 1
     assert "appears to be lost" in result.output
     mock_common_state.prune_session.assert_called_once_with("lost-sess")
+
+
+def test_cli_exec_timeout(mock_store, mock_runtime_class, mock_common_state, tmp_path):
+    mock_session = MagicMock()
+    mock_session.url = "http://url"
+    mock_session.token = "token123"
+    mock_session.name = "s1"
+    mock_session.kernel_id = None
+    mock_session.session_id = None
+    mock_store.get.return_value = mock_session
+
+    mock_common_state.resolve_session.return_value = "s1"
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = [{"text": "hello\n"}]
+
+    script = tmp_path / "script.py"
+    script.write_text("print('hello')")
+
+    result = runner.invoke(app, ["exec", "-s", "s1", "-f", str(script), "--timeout", "3600"])
+    assert result.exit_code == 0
+    mock_runtime.execute_code.assert_any_call("print('hello')", output_hook=ANY, timeout=3600.0)

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -58,7 +58,7 @@ def test_cli_exec_file(mock_store, mock_runtime_class, mock_common_state, tmp_pa
     mock_runtime.execute_code.assert_any_call(
         "import os; os.makedirs('/content', exist_ok=True); os.chdir('/content')"
     )
-    mock_runtime.execute_code.assert_any_call("print('hello')", output_hook=ANY, timeout=None)
+    mock_runtime.execute_code.assert_any_call("print('hello')", output_hook=ANY, timeout=10.0)
 
 
 def test_cli_exec_stdin(mock_store, mock_runtime_class, mock_common_state):
@@ -80,7 +80,7 @@ def test_cli_exec_stdin(mock_store, mock_runtime_class, mock_common_state):
     assert mock_session.last_execution[1] is None
     assert mock_session.last_execution[2] is not None
     mock_store.add.assert_called_with(mock_session)
-    mock_runtime.execute_code.assert_any_call("print(42)", output_hook=ANY, timeout=None)
+    mock_runtime.execute_code.assert_any_call("print(42)", output_hook=ANY, timeout=10.0)
 
 
 def test_cli_exec_not_found(mock_common_state):

--- a/tests/test_ipynb_exec.py
+++ b/tests/test_ipynb_exec.py
@@ -98,10 +98,10 @@ class TestIpynbExec(unittest.TestCase):
                 "os.chdir", mock_runtime.execute_code.call_args_list[0].args[0]
             )
             mock_runtime.execute_code.assert_any_call(
-                "print('cell 1')", output_hook=ANY, timeout=None
+                "print('cell 1')", output_hook=ANY, timeout=10.0
             )
             mock_runtime.execute_code.assert_any_call(
-                "print('cell 2')", output_hook=ANY, timeout=None
+                "print('cell 2')", output_hook=ANY, timeout=10.0
             )
 
     @patch("colab_cli.commands.execution.ColabRuntime")

--- a/tests/test_ipynb_exec.py
+++ b/tests/test_ipynb_exec.py
@@ -98,10 +98,10 @@ class TestIpynbExec(unittest.TestCase):
                 "os.chdir", mock_runtime.execute_code.call_args_list[0].args[0]
             )
             mock_runtime.execute_code.assert_any_call(
-                "print('cell 1')", output_hook=ANY
+                "print('cell 1')", output_hook=ANY, timeout=None
             )
             mock_runtime.execute_code.assert_any_call(
-                "print('cell 2')", output_hook=ANY
+                "print('cell 2')", output_hook=ANY, timeout=None
             )
 
     @patch("colab_cli.commands.execution.ColabRuntime")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -504,3 +504,28 @@ def test_run_prelude_suppresses_ipython_exit_warning(
     # Look for the warnings filter targeting IPython's exit-warning text.
     assert "warnings.filterwarnings" in body
     assert "To exit: use" in body
+
+
+def test_run_with_timeout_flag(
+    mock_client,
+    mock_store,
+    mock_runtime_class,
+    mock_spawn_keep_alive,
+    assign_response,
+    script_path,
+):
+    """`colab run --timeout 3600 script.py` must pass timeout down to the runtime."""
+    mock_client.assign.return_value = assign_response
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    persisted = {}
+    mock_store.add.side_effect = lambda s: persisted.setdefault("s", s)
+    mock_store.get.side_effect = lambda name: persisted.get("s")
+
+    result = runner.invoke(app, ["run", "--timeout", "3600", str(script_path)])
+    assert result.exit_code == 0, result.output
+
+    code_calls = mock_runtime.execute_code.call_args_list
+    body_call = next(c for c in code_calls if "hello from script" in c.args[0])
+    assert body_call.kwargs.get("timeout") == 3600.0


### PR DESCRIPTION
Background: For headless workloads (like downloading large datasets or model weights, or compiling C++ extensions) that produce no output, the 10-second default execution timeout causes a spurious TimeoutError. This PR exposes a `--timeout` flag to `colab exec` and `colab run` to allow users to increase the idle execution threshold.