### PR TITLE
fix: use cross-platform filelock instead of POSIX-only fcntl

### DIFF
--- a/docs/01_session_management.md
+++ b/docs/01_session_management.md
@@ -1,3 +1,8 @@
+---
+log:
+2026-06-10: Replaced the POSIX-only `fcntl.flock` file locking in `_LockedFileStore` with the cross-platform `filelock` library (reported broken on Windows). Reads use `ReadWriteLock.read_lock()` (shared) and writes use `write_lock()` (exclusive), preserving the original `LOCK_SH`/`LOCK_EX` semantics. The lock is constructed with `is_singleton=False` so two `StateStore` instances for the same path in one process don't collapse into a single reentrant lock (which would raise `RuntimeError` on multi-threaded write contention). Added shared-read, cross-process exclusion, and multi-thread/multi-process regression tests.
+---
+
 # Design: Session Management (`new`, `status`, `stop`, `sessions`)
 
 ## Overview
@@ -88,6 +93,12 @@ To prevent Colab VMs from being deleted due to idle timeouts (standard is ~90 mi
 - Use `requests` for robust HTTP interactions and `pydantic` for schema validation.
 - Handle authentication headers (likely `Authorization: Bearer <token>` or cookies).
 
+### State Persistence & File Locking
+- **Stores**: `StateStore` (`sessions.json`) and `SettingsStore` (`settings.json`) both derive from `_LockedFileStore`, which guards concurrent access across independent `colab` invocations and the detached keep-alive daemon.
+- **Cross-platform locking**: Locking uses the [`filelock`](https://pypi.org/project/filelock/) library rather than `fcntl.flock`. `fcntl` is POSIX-only and is unavailable on Windows, so the original implementation crashed on import there. `filelock` provides the same advisory cross-process locking on Linux, macOS, and Windows.
+- **Shared vs. exclusive**: Each store owns a `filelock.ReadWriteLock` bound to a sidecar file (`<path>.lock`). Reads acquire `read_lock()` (shared — multiple concurrent readers allowed) and writes acquire `write_lock()` (exclusive). This preserves the `LOCK_SH`/`LOCK_EX` distinction of the previous `fcntl` implementation.
+- **`is_singleton=False`**: The `ReadWriteLock` is created with `is_singleton=False`. With `filelock`'s default (`True`), two `ReadWriteLock` objects for the same path *within a single process* are deduplicated into one reentrant lock; its reentrancy guard then raises `RuntimeError` when two threads each construct their own `StateStore` and contend for the write lock. Disabling the singleton registry makes each store's lock independent so they serialize via the underlying file lock instead.
+
 ## Testing Strategy
 TDD is mandatory for all session management features.
 
@@ -100,3 +111,8 @@ TDD is mandatory for all session management features.
 ### 2. State Store Validation
 - **Test Case**: Verify `StateStore` correctly handles file locking and multiple concurrent reads/writes.
 - **Test Case**: Verify `--config` override correctly directs all operations to the specified file path.
+- **Test Case (cross-platform locking)**: Verify the store locks via `filelock.ReadWriteLock` on the `<path>.lock` sidecar and does not import the POSIX-only `fcntl`.
+- **Test Case (shared/exclusive semantics)**: Verify reads go through `read_lock()` and writes through `write_lock()`.
+- **Test Case (cross-process exclusion)**: Hold the write lock from a separate process and confirm the store's in-process write blocks until release.
+- **Test Case (concurrent readers)**: Hold a read lock from a separate process and confirm the store can still complete a read concurrently.
+- **Test Case (multi-thread regression)**: Two `StateStore` instances writing from different threads must serialize without raising `RuntimeError` (guards the `is_singleton=False` choice).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "click>=8.0",
+    "filelock>=3.29.2",
     "google-auth>=2.49.1",
     "google-auth-oauthlib>=1.3.0",
     "jupyter-kernel-client",

--- a/src/colab_cli/state.py
+++ b/src/colab_cli/state.py
@@ -15,9 +15,10 @@
 import contextlib
 import json
 import os
-import fcntl
 from datetime import datetime
 from typing import Dict, Optional, Tuple, Iterator, IO
+
+import filelock
 from pydantic import BaseModel
 
 
@@ -46,6 +47,15 @@ class Settings(BaseModel):
 class _LockedFileStore:
     def __init__(self, path: str):
         self.path = path
+        self.lock_path = "%s.lock" % self.path
+        # ReadWriteLock gives us shared (concurrent) readers and exclusive
+        # writers -- the cross-platform equivalent of fcntl LOCK_SH/LOCK_EX.
+        # is_singleton=False keeps each store's lock independent: with the
+        # default (True), two StateStore instances for the same path in one
+        # process are merged into a single reentrant lock, whose reentrancy
+        # guard then raises RuntimeError when two threads contend for the write
+        # lock. We want them to actually serialize via the underlying file lock.
+        self._rwlock = filelock.ReadWriteLock(self.lock_path, is_singleton=False)
         self._ensure_dir()
 
     def _ensure_dir(self):
@@ -63,21 +73,15 @@ class _LockedFileStore:
         if not os.path.exists(self.path):
             yield None
             return
-        with open(self.path, "r") as f:
-            fcntl.flock(f, fcntl.LOCK_SH)
-            try:
+        with self._rwlock.read_lock():
+            with open(self.path, "r") as f:
                 yield f
-            finally:
-                fcntl.flock(f, fcntl.LOCK_UN)
 
     @contextlib.contextmanager
     def _lock_exclusive(self) -> Iterator[IO]:
-        with open(self.path, "a+") as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
-            try:
+        with self._rwlock.write_lock():
+            with open(self.path, "a+") as f:
                 yield f
-            finally:
-                fcntl.flock(f, fcntl.LOCK_UN)
 
 
 class SettingsStore(_LockedFileStore):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import multiprocessing
 import os
 import pytest
 import tempfile
 import threading
 from datetime import datetime
+
+import filelock
+
 from colab_cli.state import StateStore, SessionState, SettingsStore, Settings
 
 
@@ -121,3 +125,203 @@ def test_settings_store_save_load(temp_config):
     loaded = SettingsStore(temp_config).load()
     assert loaded.enable_update_check is False
     assert loaded.last_check == datetime(2026, 1, 1)
+
+
+# --- Cross-platform locking (filelock ReadWriteLock) behavior ---------------
+
+
+def test_lock_path_is_derived_from_path(temp_config):
+    """The lock sidecar file lives next to the data file with a .lock suffix."""
+    store = StateStore(temp_config)
+    assert store.lock_path == temp_config + ".lock"
+
+
+def test_store_uses_readwrite_lock_on_sidecar(temp_config):
+    """The store holds a ReadWriteLock bound to the sidecar path."""
+    store = StateStore(temp_config)
+    assert isinstance(store._rwlock, filelock.ReadWriteLock)
+    assert store._rwlock.lock_file == temp_config + ".lock"
+
+
+def test_separate_store_instances_can_write_from_threads(temp_config):
+    """Two StateStore instances writing from different threads must not crash.
+
+    Regression guard for filelock's is_singleton=True default: it merges two
+    same-path ReadWriteLock objects into one reentrant lock whose reentrancy
+    guard raises RuntimeError when two threads contend for the write lock. We
+    pass is_singleton=False so they serialize via the underlying file lock.
+    """
+    errors = []
+
+    def writer(start):
+        store = StateStore(temp_config)
+        try:
+            for i in range(start, start + 25):
+                store.add(SessionState(name=f"n{i}", token="t", url="u", endpoint="e"))
+        except Exception as exc:  # pragma: no cover - failure path
+            errors.append(repr(exc))
+
+    threads = [threading.Thread(target=writer, args=(s,)) for s in (0, 100)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert len(StateStore(temp_config).list()) == 50
+
+
+def test_write_acquires_write_lock(temp_config, mocker):
+    """Writes go through the ReadWriteLock's exclusive write_lock()."""
+    store = StateStore(temp_config)
+    spy = mocker.spy(store._rwlock, "write_lock")
+    store.add(SessionState(name="s", token="t", url="u", endpoint="e"))
+    assert spy.call_count >= 1
+    assert store.get("s") is not None
+
+
+def test_read_acquires_read_lock(temp_config, mocker):
+    """Reads go through the ReadWriteLock's shared read_lock()."""
+    store = StateStore(temp_config)
+    store.add(SessionState(name="s", token="t", url="u", endpoint="e"))
+
+    spy = mocker.spy(store._rwlock, "read_lock")
+    assert store.get("s") is not None
+    assert spy.call_count >= 1
+
+
+def test_uses_filelock_not_fcntl(temp_config):
+    """The store must lock via the platform-independent filelock library.
+
+    Guards against a regression back to the POSIX-only fcntl.flock approach
+    that broke Windows users.
+    """
+    store = StateStore(temp_config)
+    assert store._rwlock.__class__.__module__.startswith("filelock")
+
+
+def test_no_fcntl_import_in_state_module():
+    """The state module must not depend on the POSIX-only fcntl module."""
+    import colab_cli.state as state_module
+
+    assert not hasattr(state_module, "fcntl")
+
+
+def _mp_hold_write_lock(lock_path, hold_for, acquired_evt, release_evt):
+    rw = filelock.ReadWriteLock(lock_path)
+    with rw.write_lock():
+        acquired_evt.set()
+        release_evt.wait(timeout=hold_for)
+
+
+def test_write_lock_blocks_across_processes(temp_config):
+    """A write lock held by another process must block the store's write section.
+
+    The cross-process guarantee is the whole point of the fcntl->filelock
+    switch, so we hold the write lock from a separate process and confirm the
+    in-process writer cannot proceed until it's released.
+    """
+    store = StateStore(temp_config)
+    # Pre-create the data file so add() doesn't race on first creation.
+    store.add(SessionState(name="seed", token="t", url="u", endpoint="e"))
+
+    ctx = multiprocessing.get_context("spawn")
+    acquired = ctx.Event()
+    release = ctx.Event()
+    holder = ctx.Process(
+        target=_mp_hold_write_lock, args=(store.lock_path, 10, acquired, release)
+    )
+    holder.start()
+    try:
+        assert acquired.wait(timeout=5), "holder process never acquired the lock"
+
+        finished = threading.Event()
+
+        def writer():
+            store.add(SessionState(name="blocked", token="t", url="u", endpoint="e"))
+            finished.set()
+
+        t = threading.Thread(target=writer)
+        t.start()
+
+        # While the external process holds the write lock, the writer can't finish.
+        assert not finished.wait(timeout=0.75)
+
+        release.set()
+        assert finished.wait(timeout=5)
+        t.join()
+        assert store.get("blocked") is not None
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+
+def _mp_hold_read_lock(lock_path, acquired_evt, release_evt):
+    rw = filelock.ReadWriteLock(lock_path)
+    with rw.read_lock():
+        acquired_evt.set()
+        release_evt.wait(timeout=10)
+
+
+def test_readers_are_concurrent_across_processes(temp_config):
+    """Shared read locks must allow concurrent readers (the LOCK_SH semantics).
+
+    This is the capability ReadWriteLock buys us over a plain exclusive
+    FileLock: while one process holds a read lock, this process can still read.
+    """
+    store = StateStore(temp_config)
+    store.add(SessionState(name="s", token="t", url="u", endpoint="e"))
+
+    ctx = multiprocessing.get_context("spawn")
+    acquired = ctx.Event()
+    release = ctx.Event()
+    holder = ctx.Process(
+        target=_mp_hold_read_lock, args=(store.lock_path, acquired, release)
+    )
+    holder.start()
+    try:
+        assert acquired.wait(timeout=5), "holder process never acquired the read lock"
+
+        done = threading.Event()
+        result = {}
+
+        def reader():
+            result["value"] = store.get("s")
+            done.set()
+
+        t = threading.Thread(target=reader)
+        t.start()
+
+        # The read must complete even though another process holds a read lock.
+        assert done.wait(timeout=3), "concurrent read was blocked by another reader"
+        t.join()
+        assert result["value"] is not None
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+
+def _mp_add_sessions(path, start, count):
+    store = StateStore(path)
+    for i in range(start, start + count):
+        store.add(SessionState(name=f"p{i}", token="t", url="u", endpoint="e"))
+
+
+def test_state_store_multiprocess_concurrency(temp_config):
+    """filelock must serialize writes across separate processes (not just threads).
+
+    fcntl.flock is per-open-file-description and advisory; this test exercises
+    the cross-process guarantee that motivated the switch.
+    """
+    ctx = multiprocessing.get_context("spawn")
+    p1 = ctx.Process(target=_mp_add_sessions, args=(temp_config, 0, 40))
+    p2 = ctx.Process(target=_mp_add_sessions, args=(temp_config, 40, 40))
+
+    p1.start()
+    p2.start()
+    p1.join()
+    p2.join()
+
+    assert p1.exitcode == 0
+    assert p2.exitcode == 0
+    assert len(StateStore(temp_config).list()) == 80

--- a/uv.lock
+++ b/uv.lock
@@ -277,6 +277,15 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/fa/b7dc8a63243aafe57bf53611bd26fa3e0dee2d613590656d44e0a59b7828/filelock-3.29.2.tar.gz", hash = "sha256:779d2f5443b584750c6b90457abffd49235bfb0e66ce82ef5a680867e518ca1c", size = 61449, upload-time = "2026-06-10T14:45:23.072Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/c1/91b0faf8de6938ae72da425e0c6f322d270c044e5ffc372e6f0f89ed1564/filelock-3.29.2-py3-none-any.whl", hash = "sha256:f5d3feb44b2b8824832587543af5226822fe86baf086678ede47aa177fe47ca5", size = 42129, upload-time = "2026-06-10T14:45:21.896Z" },
+]
+
+[[package]]
 name = "google-auth"
 version = "2.49.1"
 source = { registry = "https://pypi.org/simple" }
@@ -307,6 +316,7 @@ name = "google-colab-cli"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "filelock" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
     { name = "jupyter-kernel-client" },
@@ -333,6 +343,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
+    { name = "filelock", specifier = ">=3.29.2" },
     { name = "google-auth", specifier = ">=2.49.1" },
     { name = "google-auth-oauthlib", specifier = ">=1.3.0" },
     { name = "jupyter-kernel-client", git = "https://github.com/googlecolab/jupyter-kernel-client.git" },


### PR DESCRIPTION
## Summary
- Replace the POSIX-only `fcntl.flock` locking in `_LockedFileStore` with the cross-platform `filelock` library. `fcntl` is unavailable on Windows, so the state/settings stores crashed on import there (reported by Windows users).
- Preserve the original `LOCK_SH`/`LOCK_EX` semantics by using `filelock.ReadWriteLock`: reads go through `read_lock()` (shared, concurrent readers) and writes through `write_lock()` (exclusive).
- Construct the lock with `is_singleton=False` so two `StateStore` instances for the same path in one process don't collapse into a single shared (reentrant) lock object. With the default (`True`), the shared object's reentrancy guard raises `RuntimeError` when two threads contend for the write lock; `False` gives each store its own lock so they serialize via SQLite's file-level locking instead.

## Why `is_singleton=False`
`filelock`'s `ReadWriteLock` dedupes same-path instances into one object whose `_lock_level`/`_write_thread_id` model a single held transaction. When two independently-constructed stores (e.g. two threads) share that object and contend on a write, the guard fails fast with `RuntimeError` rather than blocking. Opting out of the singleton makes each store's lock independent, so mutual exclusion happens at the lock-file level (SQLite `BEGIN EXCLUSIVE` + `busy_timeout`) — correct cross-thread and cross-process serialization. We never nest acquisitions, so we don't need the in-object reentrancy.

## Tests
- `read`/`write` route through the correct `ReadWriteLock` context managers; no `fcntl` import.
- Cross-process exclusion: a write lock held by another process blocks the store's write.
- Concurrent readers: a read completes while another process holds a read lock.
- Multi-thread regression: two `StateStore`s writing from different threads serialize without `RuntimeError` (guards the `is_singleton=False` choice).
- Multi-process concurrency: interleaved writes from two processes lose no entries.
- Full suite: 223 passing; `ruff` clean on changed files.

## Docs
- `docs/01_session_management.md`: added a State Persistence & File Locking subsection, expanded the State Store Validation test cases, and a frontmatter log entry.

## Follow-up to consider
The SQLite-backed `ReadWriteLock` (filelock 3.21.0+) documents a `.db` sidecar extension; we point it at `<path>.lock`. Tests pass, but switching the sidecar to `.db` to match their convention could be worth a follow-up.
