### PR TITLE
chore: move skill into SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: colab-session-operator
+description: Operate Google Colab environments via the `colab` CLI. Use when asked to create or manage GPU/TPU sessions, run Python/shell on a remote Colab VM, sync files, automate environment setup (packages, auth, Drive), or export session history.
+---
+
 # Skill: Colab Session Operator
 
 Operate Google Colab environments via the `colab` CLI: provision GPU/TPU sessions, run Python/shell on the VM, sync files, and capture work as notebooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ packages = ["src/colab_cli"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "README.md" = "colab_cli/README.md"
-"SKILL.md" = "colab_cli/SKILL.md"
+"skills/colab-operator/SKILL.md" = "colab_cli/SKILL.md"
 
 [tool.uv]
 package = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ packages = ["src/colab_cli"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "README.md" = "colab_cli/README.md"
-"COLAB_SKILL.md" = "colab_cli/COLAB_SKILL.md"
+"SKILL.md" = "colab_cli/SKILL.md"
 
 [tool.uv]
 package = true

--- a/skills/colab-operator/SKILL.md
+++ b/skills/colab-operator/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: colab-session-operator
+name: colab-operator
 description: Operate Google Colab environments via the `colab` CLI. Use when asked to create or manage GPU/TPU sessions, run Python/shell on a remote Colab VM, sync files, automate environment setup (packages, auth, Drive), or export session history.
 ---
 

--- a/skills/colab-operator/SKILL.md
+++ b/skills/colab-operator/SKILL.md
@@ -7,6 +7,11 @@ description: Operate Google Colab environments via the `colab` CLI. Use when ask
 
 Operate Google Colab environments via the `colab` CLI: provision GPU/TPU sessions, run Python/shell on the VM, sync files, and capture work as notebooks.
 
+## Installation
+
+If the user does not already have the `colab` tool installed, it can be acquired
+by running `uv tool install google-colab-cli` or `pip install google-colab-cli`.
+
 ## When to activate
 - Creating or managing TPU/GPU sessions.
 - Running Python or shell on a remote Colab VM.

--- a/src/colab_cli/commands/utility.py
+++ b/src/colab_cli/commands/utility.py
@@ -417,8 +417,8 @@ def readme():
 
 
 def skill():
-    """Print the bundled COLAB_SKILL.md file"""
-    _print_resource("COLAB_SKILL.md")
+    """Print the bundled SKILL.md file"""
+    _print_resource("SKILL.md")
 
 
 def register(app: typer.Typer):

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -52,7 +52,7 @@ def test_skill_from_resources(mock_resources):
     mock_skill.read_text.return_value = "Fake SKILL content"
 
     def joinpath_side_effect(name):
-        if name == "COLAB_SKILL.md":
+        if name == "SKILL.md":
             return mock_skill
         return MagicMock(is_file=MagicMock(return_value=False))
 
@@ -62,7 +62,7 @@ def test_skill_from_resources(mock_resources):
     assert result.exit_code == 0
     assert result.output.strip() == "Fake SKILL content"
     mock_resources.assert_called_once_with("colab_cli")
-    mock_resources.return_value.joinpath.assert_called_with("COLAB_SKILL.md")
+    mock_resources.return_value.joinpath.assert_called_with("SKILL.md")
 
 
 def test_readme_fallback_to_file(mock_resources):


### PR DESCRIPTION
By following the [skill spec](https://agentskills.io), and putting the skill definition in a SKILL.md file, the Colab skill will be installable via community tools, e.g. `npx skills install ...` and indices like https://skills.sh/. This also allows the skill to be version managed (i.e. `skills-lock.json`) and updated (`npx skills update`).

I've also added an installation instruction to the skill so that users who stumble upon the tool via the skill have a path to onboard.

Tested, compare:

```sh
$ npx skills install markmcd/google-colab-cli#skill-md
...
◇  Installation complete
│
└  Done!  Review skills before use; they run with full agent permissions.

$ tree .agents/skills/colab-operator/
.agents/skills/colab-operator/
└── SKILL.md

$ gemini -p "write a python fibonacci function and run it in a remote colab kernel, then give me the 103rd number" --yolo
... etc :)
```

with:

```sh
$ npx skills install googlecolab/google-colab-cli
...
┌   skills
│
◇  Source: https://github.com/googlecolab/google-colab-cli.git
│
◇  Repository cloned
│
◇  No skills found
│
└  No valid skills found. Skills require a SKILL.md with name and description.
```

lmkwyt!