### PR TITLE
fix: render text/html display_data output instead of raw IPython repr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "filelock>=3.29.2",
     "google-auth>=2.49.1",
     "google-auth-oauthlib>=1.3.0",
+    "html2text>=2024.2.26",
     "jupyter-kernel-client",
     "nbformat>=5.10.4",
     "packaging>=24.0",

--- a/src/colab_cli/commands/automation.py
+++ b/src/colab_cli/commands/automation.py
@@ -18,12 +18,15 @@ import sys
 import json
 from typing import Optional, List
 import typer
+from rich.console import Console
 from typing_extensions import Annotated
 
 from colab_cli.runtime import ColabRuntime
 from colab_cli.contents import ContentsClient
 from colab_cli.auth import get_credentials
-from colab_cli.utils import get_status_code
+from colab_cli.utils import get_status_code, render_display_data
+
+_console = Console()
 
 
 # Default execute() timeout for human-in-the-loop automations (auth /
@@ -33,6 +36,7 @@ from colab_cli.utils import get_status_code
 # 10 minutes is long enough for any realistic interactive auth ceremony
 # without leaving CI hangs unbounded.
 INTERACTIVE_AUTOMATION_TIMEOUT_SEC = 600
+
 
 
 def run_automation(
@@ -153,8 +157,9 @@ def run_automation(
             if "text" in out:
                 sys.stdout.write(out["text"])
             elif "data" in out:
-                if "text/plain" in out["data"]:
-                    typer.echo(out["data"]["text/plain"])
+                text = render_display_data(out["data"])
+                if text is not None:
+                    _console.print(text)
             elif out.get("output_type") == "error":
                 ename = out.get("ename", "Error")
                 evalue = out.get("evalue", "")

--- a/src/colab_cli/commands/execution.py
+++ b/src/colab_cli/commands/execution.py
@@ -20,12 +20,15 @@ import sys
 import typer
 import uuid
 from nbformat.v4 import new_output
+from rich.console import Console
 from typing import Optional
 from typing_extensions import Annotated
 
 from colab_cli.runtime import ColabRuntime
-from colab_cli.utils import handle_image, is_terminal_error
+from colab_cli.utils import handle_image, is_terminal_error, render_display_data
 from colab_cli.console import connect_console
+
+_console = Console()
 
 TITLE_REGEX = re.compile(r"^\s*#\s*@title\s+(.*)", re.MULTILINE)
 
@@ -72,6 +75,7 @@ def save_output(outputs, cell):
             )
 
 
+
 def display_output(out, output_image=None):
     if out.get("output_type") == "stream":
         stream = sys.stderr if out.get("name") == "stderr" else sys.stdout
@@ -79,8 +83,9 @@ def display_output(out, output_image=None):
         stream.flush()
     elif "data" in out:
         data = out["data"]
-        if text := data.get("text/plain"):
-            typer.echo(text)
+        text = render_display_data(data)
+        if text is not None:
+            _console.print(text)
         if png := data.get("image/png"):
             handle_image(png, "image/png", target_path=output_image)
         elif jpeg := data.get("image/jpeg"):

--- a/src/colab_cli/repl.py
+++ b/src/colab_cli/repl.py
@@ -25,9 +25,8 @@ from rich.console import Console
 from rich.text import Text
 
 from colab_cli.runtime import ColabRuntime
-from colab_cli.utils import handle_image
+from colab_cli.utils import handle_image, render_display_data
 
-console = Console()
 
 
 class ColabREPL:
@@ -43,7 +42,7 @@ class ColabREPL:
         self.history_logger = history_logger
         self.output_image = output_image
         self.kb = KeyBindings()
-        self.console = console
+        self.console = Console()
         self.repl_history: List[dict] = []
 
         @self.kb.add("enter")
@@ -91,14 +90,16 @@ class ColabREPL:
                     image_displayed = True
                     break
 
-            if "text/plain" in data:
-                text = data["text/plain"]
+            text = render_display_data(data)
+            if text is not None:
                 # Skip generic IPython object reprs if we already showed an image
-                if image_displayed and any(
-                    x in text for x in ["<IPython.core.display.Image", "<Figure size"]
-                ):
-                    return
-                self.console.print(Text.from_ansi(text))
+                if isinstance(text, Text) and image_displayed:
+                    if any(
+                        x in text.plain
+                        for x in ["<IPython.core.display.Image", "<Figure size"]
+                    ):
+                        return
+                self.console.print(text)
         elif output.get("output_type") == "error":
             ename = output.get("ename", "Error")
             evalue = output.get("evalue", "")

--- a/src/colab_cli/utils.py
+++ b/src/colab_cli/utils.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 import base64
+import html2text
 import logging
 import sys
 import tempfile
 
+from typing import Optional, Union
 
-from typing import Optional
+from rich.markdown import Markdown
+from rich.text import Text
 
 
 def get_status_code(e: Exception) -> Optional[int]:
@@ -64,6 +67,22 @@ def print_kitty(image_bytes: bytes):
         sys.stdout.flush()
     except Exception:
         logging.exception("Kitty rendering failed")
+
+
+def render_display_data(data: dict) -> Union[Markdown, Text, None]:
+    """Extract the best text representation from a display_data dict.
+
+    Priority: text/markdown > text/html (via html2text) > text/plain.
+    Returns a Rich renderable (Markdown or Text) or None when no text mime
+    type is present.  Callers can pass the result directly to Console.print().
+    """
+    if "text/markdown" in data:
+        return Markdown(data["text/markdown"])
+    if "text/html" in data:
+        return Markdown(html2text.html2text(data["text/html"]))
+    if "text/plain" in data:
+        return Text.from_ansi(data["text/plain"])
+    return None
 
 
 def handle_image(image_b64: str, mime_type: str = "image/png", target_path: str = None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,11 @@
 import base64
 from unittest.mock import MagicMock, patch
 
-from colab_cli.utils import handle_image, print_kitty
+import pytest
+from rich.markdown import Markdown
+from rich.text import Text
+
+from colab_cli.utils import handle_image, print_kitty, render_display_data
 
 
 @patch("colab_cli.utils.sys.stdout.isatty", return_value=True)
@@ -56,3 +60,28 @@ def test_handle_image(mock_print_kitty, mock_tempfile, capsys):
 
     captured = capsys.readouterr()
     assert "/tmp/fake.png" in captured.out
+
+
+@pytest.mark.parametrize(
+    "data, expected_markup",
+    [
+        ({"text/markdown": "**md**"}, "**md**"),
+        ({"text/html": "<b>hi</b>"}, "**hi**\n\n"),
+        ({"text/markdown": "**md**", "text/html": "<b>hi</b>"}, "**md**"),
+        ({"text/html": "<b>hi</b>", "text/plain": "plain"}, "**hi**\n\n"),
+    ],
+)
+def test_render_display_data_markdown(data, expected_markup):
+    result = render_display_data(data)
+    assert isinstance(result, Markdown)
+    assert result.markup == expected_markup
+
+
+def test_render_display_data_plain():
+    result = render_display_data({"text/plain": "plain"})
+    assert isinstance(result, Text)
+    assert result.plain == "plain"
+
+
+def test_render_display_data_none():
+    assert render_display_data({"image/png": "..."}) is None

--- a/uv.lock
+++ b/uv.lock
@@ -319,6 +319,7 @@ dependencies = [
     { name = "filelock" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
+    { name = "html2text" },
     { name = "jupyter-kernel-client" },
     { name = "nbformat" },
     { name = "packaging" },
@@ -346,6 +347,7 @@ requires-dist = [
     { name = "filelock", specifier = ">=3.29.2" },
     { name = "google-auth", specifier = ">=2.49.1" },
     { name = "google-auth-oauthlib", specifier = ">=1.3.0" },
+    { name = "html2text", specifier = ">=2024.2.26" },
     { name = "jupyter-kernel-client", git = "https://github.com/googlecolab/jupyter-kernel-client.git" },
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "packaging", specifier = ">=24.0" },
@@ -365,6 +367,15 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.15.6" },
+]
+
+[[package]]
+name = "html2text"
+version = "2025.4.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/27/e158d86ba1e82967cc2f790b0cb02030d4a8bef58e0c79a8590e9678107f/html2text-2025.4.15.tar.gz", hash = "sha256:948a645f8f0bc3abe7fd587019a2197a12436cd73d0d4908af95bfc8da337588", size = 64316, upload-time = "2025-04-15T04:02:30.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl", hash = "sha256:00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc", size = 34656, upload-time = "2025-04-15T04:02:28.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
When a kernel cell produces a rich display object like
`IPython.display.HTML`, the `display_data` message includes both
`text/html` (the actual content) and `text/plain` (the Python repr,
e.g. `<IPython.core.display.HTML object>`).

All three `display_output` paths — `colab exec`, `colab run`, and
the REPL — only checked for `text/plain` in the data dict and printed
that raw repr, which is useless to the user.

This adds a `text/html` branch ahead of the `text/plain` fallback
in all three locations. HTML tags are stripped for terminal display
via `html.parser.HTMLParser`. The result isn't a full HTML renderer,
but it surfaces the actual content — which is a clear improvement
over the current behavior of printing the Python object repr.

Fixes in:
- `execution.py` — `display_output()`
- `automation.py` — inline output loop in `run_automation()`
- `repl.py` — `ColabREPL.display_output()`