### PR TITLE
docs: add CHANGELOG.md for v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The package version is derived from the git tag via `hatch-vcs`; each release
+below corresponds to a tag of the same name.
+
+## [0.6.0] - 2026-06-16
+
+### Changed
+
+- **auth:** OAuth2 login now uses a remote copy-paste flow instead of a
+  localhost callback server. The CLI prints an authorization URL with
+  `redirect_uri=https://sdk.cloud.google.com/applicationdefaultauthcode.html`
+  and `token_usage=remote`, then reads the pasted code from stdin. This works
+  in headless/remote environments where a browser cannot reach a local
+  callback port. (#54)
+
+### Added
+
+- **display output:** Rich rendering for `display_data` output via a shared
+  `render_display_data()` helper. HTML is converted with `html2text` and
+  rendered as Markdown, following a `text/markdown > text/html > text/plain`
+  priority; `text/plain` is wrapped with `Text.from_ansi` to preserve embedded
+  ANSI escapes. Applied consistently across `exec`, `console`/`repl`, and
+  automation call sites. (#58)
+
+### Fixed
+
+- **keep-alive:** Replace the `RuntimeService/KeepAliveAssignment` RPC on
+  `colab.pa.googleapis.com` with a Tunnel Frontend (TFE) HTTP ping
+  (`GET /tun/m/<endpoint>/keep-alive/` with `X-Colab-Tunnel: Google`) on
+  `colab.research.google.com`, authenticated by the user's own bearer token.
+  The old RPC required `serviceusage` consumer access to Colab's internal
+  project and returned HTTP 403 `USER_PROJECT_DENIED` for every external user,
+  causing their sessions to be idle-pruned within minutes. The TFE ping needs
+  no project entitlement; because the VM often does not answer on this path, a
+  `ReadTimeout` is treated as success while genuine HTTP errors propagate.
+  (#14, #61)
+
+### Removed
+
+- Dead grpc-web client-registry / API-key code path and the now-irrelevant
+  `colaboratory`-scope / `pa.googleapis.com` pre-flight remediation messaging,
+  superseded by the TFE keep-alive ping. (#61)
+
+[0.6.0]: https://github.com/googlecolab/google-colab-cli/compare/v0.5.11...v0.6.0


### PR DESCRIPTION
## Summary
- Adds a `CHANGELOG.md` (Keep a Changelog format) documenting the **v0.6.0** release.
- The `v0.6.0` tag has been pushed and points at this commit (atop the #58 fix on `main`).

## v0.6.0 contents
- **Added** — Rich `display_data` rendering via `render_display_data()` (#58)
- **Changed** — remote copy-paste OAuth2 flow (#54)
- **Fixed** — keep-alive switched to TFE tunnel ping (#14, #61)
- **Removed** — dead grpc-web client-registry / API-key code (#61)

## Notes
- Version is VCS-derived via `hatch-vcs`, so the tag drives the package version; no `pyproject.toml` edit needed.
