### PR TITLE
feat: Add --env KEY=VALUE flag to colab run and colab exec to inject environment variables

### DIFF
--- a/src/colab_cli/commands/execution.py
+++ b/src/colab_cli/commands/execution.py
@@ -21,7 +21,7 @@ import typer
 import uuid
 from nbformat.v4 import new_output
 from rich.console import Console
-from typing import Optional
+from typing import List, Optional
 from typing_extensions import Annotated
 
 from colab_cli.runtime import ColabRuntime
@@ -31,10 +31,45 @@ from colab_cli.console import connect_console
 _console = Console()
 
 TITLE_REGEX = re.compile(r"^\s*#\s*@title\s+(.*)", re.MULTILINE)
+ENV_KEY_REGEX = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def is_stdin_tty():
     return sys.stdin.isatty()
+
+
+def _parse_env_vars(env: Optional[List[str]]) -> dict[str, str]:
+    """Parse repeatable --env KEY=VALUE entries into an ordered mapping."""
+    env_vars = {}
+    for item in env or []:
+        if "=" not in item:
+            typer.echo(
+                f"[colab] Invalid --env value {item!r}. Expected KEY=VALUE.",
+                err=True,
+            )
+            raise typer.Exit(2)
+
+        key, value = item.split("=", 1)
+        if not ENV_KEY_REGEX.fullmatch(key):
+            typer.echo(
+                f"[colab] Invalid --env key {key!r}. Expected a valid "
+                "environment variable name.",
+                err=True,
+            )
+            raise typer.Exit(2)
+
+        env_vars[key] = value
+    return env_vars
+
+
+def _build_env_prelude(env_vars: dict[str, str]) -> str:
+    """Build Python source that sets environment variables in the remote kernel."""
+    if not env_vars:
+        return ""
+
+    lines = ["import os"]
+    lines.extend(f"os.environ[{key!r}] = {value!r}" for key, value in env_vars.items())
+    return "\n".join(lines) + "\n"
 
 
 def save_output(outputs, cell):
@@ -73,7 +108,6 @@ def save_output(outputs, cell):
                     traceback=out.get("traceback", []),
                 )
             )
-
 
 
 def display_output(out, output_image=None):
@@ -117,10 +151,21 @@ def exec_command(
         Optional[float],
         typer.Option("--timeout", help="Timeout in seconds for code execution"),
     ] = 30.0,
+    env: Annotated[
+        Optional[List[str]],
+        typer.Option(
+            "--env",
+            help=(
+                "Set an environment variable in the remote kernel as KEY=VALUE. "
+                "Repeat for multiple variables."
+            ),
+        ),
+    ] = None,
 ):
     """Execute code in a session"""
     from colab_cli.common import state
 
+    env_vars = _parse_env_vars(env)
     name = state.resolve_session(session)
     s = state.store.get(name)
     if not s:
@@ -190,7 +235,7 @@ def exec_command(
         state.store.add(s)
 
         for i, block in enumerate(code_blocks):
-            code = block["code"]
+            code = _build_env_prelude(env_vars) + block["code"]
             identifier = None
             if is_nb:
                 title_match = TITLE_REGEX.search(code)

--- a/src/colab_cli/commands/run.py
+++ b/src/colab_cli/commands/run.py
@@ -44,6 +44,7 @@ from colab_cli.client import (
     PostAssignmentResponse,
     Variant,
 )
+from colab_cli.commands.execution import _build_env_prelude, _parse_env_vars
 from colab_cli.commands.session import (
     _is_scope_error,
     _scope_remediation_message,
@@ -75,12 +76,15 @@ def _resolve_accelerator(gpu: Optional[str], tpu: Optional[str]):
     return Variant.DEFAULT, Accelerator.NONE
 
 
-def _build_script_payload(script_path: str, script_args: List[str]) -> str:
+def _build_script_payload(
+    script_path: str, script_args: List[str], env_vars: Optional[dict[str, str]] = None
+) -> str:
     """Wrap the script body so it executes with native-`python`-like semantics.
 
     Specifically:
       - `sys.argv = [<basename>, *script_args]` so `argparse` etc. work.
       - `__name__ = '__main__'` so `if __name__ == "__main__":` guards fire.
+      - Requested `--env KEY=VALUE` pairs are written into `os.environ`.
       - Suppress the IPython UserWarning "To exit: use 'exit', 'quit', or
         Ctrl-D." which fires whenever the script calls `sys.exit(...)`. This
         warning is meaningful in an interactive REPL, but for `colab run` it
@@ -102,8 +106,40 @@ def _build_script_payload(script_path: str, script_args: List[str]) -> str:
         f"sys.argv = {argv_literal}\n"
         "__name__ = '__main__'\n"
         "warnings.filterwarnings('ignore', message=\"To exit: use\")\n"
+        + _build_env_prelude(env_vars or {})
         + _strip_shebang(body)
     )
+
+
+def _extract_env_args_from_script_args(
+    script_args: List[str],
+) -> tuple[List[str], List[str]]:
+    """Pull colab's --env options out of variadic script args.
+
+    `colab run` intentionally forwards unknown options after the script path to
+    the user's script. Since `--env` is now a colab option, support both
+    `colab run --env KEY=VALUE script.py` (Typer parses this) and
+    `colab run script.py --env KEY=VALUE` (this helper parses it).
+    """
+    forwarded_args = []
+    env = []
+    i = 0
+    while i < len(script_args):
+        arg = script_args[i]
+        if arg == "--env":
+            if i + 1 >= len(script_args):
+                env.append("")
+                i += 1
+            else:
+                env.append(script_args[i + 1])
+                i += 2
+        elif arg.startswith("--env="):
+            env.append(arg.split("=", 1)[1])
+            i += 1
+        else:
+            forwarded_args.append(arg)
+            i += 1
+    return forwarded_args, env
 
 
 def _strip_shebang(body: str) -> str:
@@ -237,6 +273,16 @@ def run_command(
         Optional[float],
         typer.Option("--timeout", help="Timeout in seconds for code execution"),
     ] = 30.0,
+    env: Annotated[
+        Optional[List[str]],
+        typer.Option(
+            "--env",
+            help=(
+                "Set an environment variable in the remote kernel as KEY=VALUE. "
+                "Repeat for multiple variables."
+            ),
+        ),
+    ] = None,
 ):
     """Run a Python script on a fresh Colab VM, then release the VM
 
@@ -250,6 +296,8 @@ def run_command(
     from colab_cli.common import state
 
     script_args = script_args or []
+    script_args, inline_env = _extract_env_args_from_script_args(script_args)
+    env_vars = _parse_env_vars([*(env or []), *inline_env])
 
     # AGENTS.md item 10: validate locally BEFORE allocating a VM. A typo'd
     # script path should not cost the user real compute.
@@ -379,7 +427,7 @@ def run_command(
                 raise typer.Exit(1)
             raise
 
-        payload = _build_script_payload(script, script_args)
+        payload = _build_script_payload(script, script_args, env_vars)
         s.running = f"run({os.path.basename(script)})"
         s.last_execution = (
             script,

--- a/tests/test_exec.py
+++ b/tests/test_exec.py
@@ -87,6 +87,100 @@ def test_cli_exec_stdin(mock_store, mock_runtime_class, mock_common_state):
     )
 
 
+def test_cli_exec_env_injects_prelude(
+    mock_store, mock_runtime_class, mock_common_state
+):
+    mock_session = MagicMock()
+    mock_session.name = "s1"
+    mock_session.url = "http://url"
+    mock_session.token = "token"
+    mock_session.kernel_id = None
+    mock_session.session_id = None
+    mock_store.get.return_value = mock_session
+
+    mock_common_state.resolve_session.return_value = "s1"
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    code = "import os\nprint(os.environ.get('HF_TOKEN'))"
+    result = runner.invoke(
+        app, ["exec", "-s", "s1", "--env", "HF_TOKEN=abc"], input=code
+    )
+
+    assert result.exit_code == 0, result.output
+    expected = "import os\nos.environ['HF_TOKEN'] = 'abc'\n" + code
+    mock_runtime.execute_code.assert_any_call(expected, output_hook=ANY, timeout=30.0)
+
+
+def test_cli_exec_env_flags_accumulate_and_split_on_first_equals(
+    mock_store, mock_runtime_class, mock_common_state
+):
+    mock_session = MagicMock()
+    mock_session.name = "s1"
+    mock_session.url = "http://url"
+    mock_session.token = "token"
+    mock_session.kernel_id = None
+    mock_session.session_id = None
+    mock_store.get.return_value = mock_session
+
+    mock_common_state.resolve_session.return_value = "s1"
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    result = runner.invoke(
+        app,
+        ["exec", "-s", "s1", "--env", "HF_TOKEN=abc", "--env", "B64=a=b=c"],
+        input="print('ok')",
+    )
+
+    assert result.exit_code == 0, result.output
+    expected = (
+        "import os\n"
+        "os.environ['HF_TOKEN'] = 'abc'\n"
+        "os.environ['B64'] = 'a=b=c'\n"
+        "print('ok')"
+    )
+    mock_runtime.execute_code.assert_any_call(expected, output_hook=ANY, timeout=30.0)
+
+
+def test_cli_exec_env_escapes_tricky_literals(
+    mock_store, mock_runtime_class, mock_common_state
+):
+    mock_session = MagicMock()
+    mock_session.name = "s1"
+    mock_session.url = "http://url"
+    mock_session.token = "token"
+    mock_session.kernel_id = None
+    mock_session.session_id = None
+    mock_store.get.return_value = mock_session
+
+    mock_common_state.resolve_session.return_value = "s1"
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    value = "quote'back\\slash=µ"
+    result = runner.invoke(
+        app, ["exec", "-s", "s1", "--env", f"TRICKY={value}"], input="print('ok')"
+    )
+
+    assert result.exit_code == 0, result.output
+    expected = f"import os\nos.environ['TRICKY'] = {value!r}\nprint('ok')"
+    mock_runtime.execute_code.assert_any_call(expected, output_hook=ANY, timeout=30.0)
+
+
+def test_cli_exec_malformed_env_errors_before_session_resolution(
+    mock_runtime_class, mock_common_state
+):
+    result = runner.invoke(
+        app, ["exec", "-s", "s1", "--env", "HF_TOKEN"], input="print('ok')"
+    )
+
+    assert result.exit_code != 0
+    assert "Expected KEY=VALUE" in result.output
+    mock_common_state.resolve_session.assert_not_called()
+    mock_runtime_class.assert_not_called()
+
+
 def test_cli_exec_not_found(mock_common_state):
     # Case where resolve_session fails
     mock_common_state.resolve_session.side_effect = SystemExit(1)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -186,6 +186,105 @@ def test_run_passes_argv(
     assert "'--flag-for-script'" in body
 
 
+def test_run_env_flag_after_script_sets_env_and_preserves_argv(
+    mock_client,
+    mock_store,
+    mock_runtime_class,
+    mock_spawn_keep_alive,
+    assign_response,
+    script_path,
+):
+    """`--env KEY=VALUE` after the script path should configure the remote
+    environment, not get forwarded into sys.argv."""
+    mock_client.assign.return_value = assign_response
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    persisted = {}
+    mock_store.add.side_effect = lambda s: persisted.setdefault("s", s)
+    mock_store.get.side_effect = lambda name: persisted.get("s")
+
+    result = runner.invoke(
+        app, ["run", str(script_path), "--env", "HF_TOKEN=abc", "alpha"]
+    )
+
+    assert result.exit_code == 0, result.output
+    code_calls = [c.args[0] for c in mock_runtime.execute_code.call_args_list]
+    body = next(c for c in code_calls if "hello from script" in c)
+    assert "import os\n" in body
+    assert "os.environ['HF_TOKEN'] = 'abc'" in body
+    assert body.index("os.environ['HF_TOKEN'] = 'abc'") < body.index(
+        "print('hello from script')"
+    )
+    assert "'alpha'" in body
+    assert "'--env'" not in body
+    assert "'HF_TOKEN=abc'" not in body
+
+
+def test_run_env_flags_accumulate_and_split_on_first_equals(
+    mock_client,
+    mock_store,
+    mock_runtime_class,
+    mock_spawn_keep_alive,
+    assign_response,
+    script_path,
+):
+    """Repeated env flags should all become assignments; values may contain
+    additional '=' characters."""
+    mock_client.assign.return_value = assign_response
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    persisted = {}
+    mock_store.add.side_effect = lambda s: persisted.setdefault("s", s)
+    mock_store.get.side_effect = lambda name: persisted.get("s")
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--env",
+            "HF_TOKEN=abc",
+            "--env",
+            "B64=a=b=c",
+            str(script_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    code_calls = [c.args[0] for c in mock_runtime.execute_code.call_args_list]
+    body = next(c for c in code_calls if "hello from script" in c)
+    assert "os.environ['HF_TOKEN'] = 'abc'" in body
+    assert "os.environ['B64'] = 'a=b=c'" in body
+
+
+def test_run_env_flag_escapes_tricky_literals(
+    mock_client,
+    mock_store,
+    mock_runtime_class,
+    mock_spawn_keep_alive,
+    assign_response,
+    script_path,
+):
+    """Quotes, backslashes, '=' and non-ASCII values should round-trip as safe
+    Python literals."""
+    mock_client.assign.return_value = assign_response
+    mock_runtime = mock_runtime_class.return_value
+    mock_runtime.execute_code.return_value = []
+
+    persisted = {}
+    mock_store.add.side_effect = lambda s: persisted.setdefault("s", s)
+    mock_store.get.side_effect = lambda name: persisted.get("s")
+
+    value = "quote'back\\slash=µ"
+    result = runner.invoke(app, ["run", "--env", f"TRICKY={value}", str(script_path)])
+
+    assert result.exit_code == 0, result.output
+    code_calls = [c.args[0] for c in mock_runtime.execute_code.call_args_list]
+    body = next(c for c in code_calls if "hello from script" in c)
+    assert f"os.environ['TRICKY'] = {value!r}" in body
+
+
 def test_run_sets_dunder_main(
     mock_client,
     mock_store,
@@ -349,6 +448,15 @@ def test_run_nonexistent_script_errors_before_assign(mock_client):
     otherwise a typo would burn billable compute."""
     result = runner.invoke(app, ["run", "/no/such/file.py"])
     assert result.exit_code != 0
+    mock_client.assign.assert_not_called()
+
+
+def test_run_malformed_env_errors_before_assign(mock_client, script_path):
+    """Malformed env entries must be rejected locally before any VM allocation."""
+    result = runner.invoke(app, ["run", str(script_path), "--env", "HF_TOKEN"])
+
+    assert result.exit_code != 0
+    assert "Expected KEY=VALUE" in result.output
     mock_client.assign.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
google.colab.userdata.get() throws TimeoutException in CLI mode, so users have no clean way to pass secrets (HF_TOKEN, WANDB_API_KEY, etc.) to scripts run via colab run/colab exec. The reporter lists three options; maintainer teeler (CONTRIBUTOR, commented 2026-06-15) acknowledged it as a known issue and tagged the full userdata-API fix for later work because secrets are a separate backend API.

## Changes
Add a repeatable `--env KEY=VALUE` typer.Option (List[str]) to run_command in run.py and to exec_command in execution.py. Parse each entry into a dict (splitting on the first '='), validate the key, and prepend an os.environ-setup prelude to the executed code.

Fixes #48
