### PR TITLE
fix: explicitly send input_reply via wsclient when stdin_hook is invoked

### DIFF
--- a/src/colab_cli/runtime.py
+++ b/src/colab_cli/runtime.py
@@ -194,6 +194,37 @@ class ColabRuntime:
 
             res = original_stdin_hook(prompt) if original_stdin_hook else input(prompt)
 
+            wsclient = None
+            if self.kernel_client and hasattr(self.kernel_client, "_manager"):
+                wsclient = getattr(self.kernel_client._manager, "client", None)
+
+            if wsclient and hasattr(wsclient, "stdin_channel"):
+                try:
+                    content = {"value": res}
+                    reply_msg = wsclient.session.msg("input_reply", content)
+                    if isinstance(prompt, dict) and "header" in prompt:
+                        reply_msg["parent_header"] = prompt["header"]
+                    wsclient.stdin_channel.send(reply_msg)
+                    logger.info(
+                        "[wrapped_stdin_hook] Successfully sent input_reply to kernel WebSocket via wsclient."
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[wrapped_stdin_hook] Failed to send input_reply: {e}",
+                        exc_info=True,
+                    )
+            elif self.kernel_client and hasattr(self.kernel_client, "input"):
+                try:
+                    self.kernel_client.input(res)
+                    logger.info(
+                        "[wrapped_stdin_hook] Successfully sent input_reply to kernel WebSocket."
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"[wrapped_stdin_hook] Failed to send input_reply: {e}",
+                        exc_info=True,
+                    )
+
             if self.history and self.session_name:
                 self.history.log_event(self.session_name, "input_reply", {"value": res})
             return res


### PR DESCRIPTION
### Summary
When executing non-interactive code with `allow_stdin=True` and providing a custom `stdin_hook` to `ColabRuntime.execute_code`, any user input captured by the hook causes the kernel execution to stall indefinitely waiting for an `input_reply` WebSocket message.

### Root Cause
In `wrapped_stdin_hook` (`src/colab_cli/runtime.py`), after `original_stdin_hook` returns the user's input string (`res`), `execute_interactive` (`jupyter_kernel_client.wsclient`) simply loops (`continue`) without sending `input_reply`. It expects whoever intercepted `stdin_request` to send the `input_reply` back to the kernel.

Previously, `wrapped_stdin_hook` did not explicitly construct and transmit `input_reply` over `wsclient.stdin_channel` (or attempted to call `self.kernel_client.input(res)`, which fails because `KernelClient` does not have an `.input()` method — `.input()` and `.stdin_channel` belong to `_manager.client` (`KernelWebSocketClient`)).

### Solution
This PR updates `wrapped_stdin_hook` so that after obtaining the response from `original_stdin_hook`:
1. It accesses `wsclient = self.kernel_client._manager.client`.
2. Constructs the `input_reply` message dictionary and attaches the `parent_header` from the incoming `stdin_request` prompt (`prompt["header"]`) so the kernel properly correlates the reply to the request.
3. Transmits the reply over `wsclient.stdin_channel.send(reply_msg)`.
4. Falls back to `self.kernel_client.input(res)` if present.

This ensures all custom `stdin_hook` implementations (e.g. interactive UI dialogs, custom terminal input bridges) reliably resume remote execution after handling `input()/getpass()` prompts.