### PR TITLE
fix: support both ColabKernelClient and KernelClient in runtime

### DIFF
--- a/src/colab_cli/runtime.py
+++ b/src/colab_cli/runtime.py
@@ -103,16 +103,28 @@ class ColabRuntime:
                         # WSSession (Session) expects 'session' for the ID
                         client_kwargs["session"] = self.session_id
 
-                    self._kernel_client = jupyter_kernel_client.KernelClient(
-                        server_url=self.url,
-                        token=self.token,
-                        kernel_id=self.kernel_id,
-                        client_kwargs=client_kwargs,
-                        headers={
-                            "X-Colab-Client-Agent": "colab-cli",
-                            "X-Colab-Runtime-Proxy-Token": self.token,
-                        },
-                    )
+                    if hasattr(jupyter_kernel_client, "ColabKernelClient"):
+                        self._kernel_client = jupyter_kernel_client.ColabKernelClient(
+                            server_url=self.url,
+                            proxy_token=self.token,
+                            kernel_id=self.kernel_id,
+                            client_kwargs=client_kwargs,
+                            headers={
+                                "X-Colab-Client-Agent": "colab-cli",
+                                "X-Colab-Runtime-Proxy-Token": self.token,
+                            },
+                        )
+                    else:
+                        self._kernel_client = jupyter_kernel_client.KernelClient(
+                            server_url=self.url,
+                            token=self.token,
+                            kernel_id=self.kernel_id,
+                            client_kwargs=client_kwargs,
+                            headers={
+                                "X-Colab-Client-Agent": "colab-cli",
+                                "X-Colab-Runtime-Proxy-Token": self.token,
+                            },
+                        )
                     # Force _own_kernel to False. This prevents jupyter-kernel-client
                     # from automatically deleting the kernel when the client is closed or deleted.
                     self._kernel_client._own_kernel = False

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -19,31 +19,34 @@ import jupyter_kernel_client
 from colab_cli.runtime import ColabRuntime
 
 
-@patch("colab_cli.runtime.jupyter_kernel_client.KernelClient")
-def test_colab_runtime_kernel_client(mock_kc_cls):
-    mock_kc = mock_kc_cls.return_value
+def test_colab_runtime_kernel_client():
+    target_attr = "ColabKernelClient" if hasattr(jupyter_kernel_client, "ColabKernelClient") else "KernelClient"
+    token_param_name = "proxy_token" if hasattr(jupyter_kernel_client, "ColabKernelClient") else "token"
 
-    runtime = ColabRuntime("http://url", "token123")
+    with patch.object(jupyter_kernel_client, target_attr) as mock_kc_cls:
+        mock_kc = mock_kc_cls.return_value
+        runtime = ColabRuntime("http://url", "token123")
 
-    assert runtime._kernel_client is None
+        assert runtime._kernel_client is None
 
-    kc = runtime.kernel_client
+        kc = runtime.kernel_client
 
-    mock_kc_cls.assert_called_once_with(
-        server_url="http://url",
-        token="token123",
-        kernel_id=None,
-        client_kwargs={
-            "subprotocol": jupyter_kernel_client.JupyterSubprotocol.DEFAULT,
-            "extra_params": {"colab-runtime-proxy-token": "token123"},
-        },
-        headers={
-            "X-Colab-Client-Agent": "colab-cli",
-            "X-Colab-Runtime-Proxy-Token": "token123",
-        },
-    )
-    mock_kc.start.assert_called_once()
-    assert kc == mock_kc
+        expected_kwargs = {
+            "server_url": "http://url",
+            token_param_name: "token123",
+            "kernel_id": None,
+            "client_kwargs": {
+                "subprotocol": jupyter_kernel_client.JupyterSubprotocol.DEFAULT,
+                "extra_params": {"colab-runtime-proxy-token": "token123"},
+            },
+            "headers": {
+                "X-Colab-Client-Agent": "colab-cli",
+                "X-Colab-Runtime-Proxy-Token": "token123",
+            },
+        }
+        mock_kc_cls.assert_called_once_with(**expected_kwargs)
+        mock_kc.start.assert_called_once()
+        assert kc == mock_kc
 
 
 def test_colab_runtime_execute_code():


### PR DESCRIPTION
### Summary
Fixes an `AttributeError` when running `colab run` / `colab exec` caused by attribute differences between PyPI releases of `jupyter-kernel-client` (`KernelClient`) and the git repository fork (`ColabKernelClient`).

### Root Cause
- PyPI release of `jupyter-kernel-client` exports `KernelClient`.
- Git repository fork of `jupyter-kernel-client` exports `ColabKernelClient`.
- When installed as a package via `pip install google-colab-cli` or `uv tool install google-colab-cli`, `jupyter-kernel-client` from PyPI is resolved, causing `AttributeError: module 'jupyter_kernel_client' has no attribute 'KernelClient'`.

### Fix
Added dynamic attribute inspection in `ColabRuntime.kernel_client` to instantiate `ColabKernelClient` when present and fall back to `KernelClient`. Updated `test_runtime.py` unit tests accordingly.

### Testing
- Executed full test suite (`uv run pytest`): 322/322 passed.
- Verified live script execution via `colab run` on Google Colab VM.