### PR TITLE
fix: Add Windows compatibility and JupyterKernelClient fallback

### DIFF
--- a/src/colab_cli/commands/automation.py
+++ b/src/colab_cli/commands/automation.py
@@ -102,8 +102,11 @@ def run_automation(
                 state.history.log_event(s.name, "drive_auth_needed", {"uri": uri})
                 sys.stdout.write("Press Enter after you have granted access... ")
                 sys.stdout.flush()
-                with open("/dev/tty") as tty:
-                    tty.readline()
+                try:
+                    with open("/dev/tty") as tty_file:
+                        tty_file.readline()
+                except (OSError, FileNotFoundError):
+                    sys.stdin.readline()
 
             typer.echo("[colab] Authorizing VM...")
             params["dryrun"] = "false"

--- a/src/colab_cli/console.py
+++ b/src/colab_cli/console.py
@@ -17,10 +17,14 @@ import logging
 import os
 import signal
 import sys
-import termios
+try:
+    import termios
+    import tty
+except ImportError:
+    termios = None
+    tty = None
 import threading
 import time
-import tty
 from urllib.parse import urlparse
 
 import websocket
@@ -133,8 +137,8 @@ def connect_console(session: SessionState):
     ws_url = f"{ws_scheme}://{parsed.netloc}/colab/tty?colab-runtime-proxy-token={session.token}"
 
     is_tty = sys.stdin.isatty()
-    fd = sys.stdin.fileno() if is_tty else None
-    old_settings = termios.tcgetattr(fd) if is_tty else None
+    fd = sys.stdin.fileno() if (is_tty and hasattr(sys.stdin, "fileno")) else None
+    old_settings = termios.tcgetattr(fd) if (is_tty and termios and fd is not None) else None
 
     ws = websocket.WebSocketApp(
         url=ws_url,
@@ -151,8 +155,10 @@ def connect_console(session: SessionState):
 
     try:
         if is_tty:
-            tty.setraw(fd, termios.TCSANOW)
-            signal.signal(signal.SIGWINCH, handle_sigwinch)
+            if tty and termios and fd is not None:
+                tty.setraw(fd, termios.TCSANOW)
+            if hasattr(signal, "SIGWINCH"):
+                signal.signal(signal.SIGWINCH, handle_sigwinch)
 
         # This is a blocking call until the connection is closed
         ws.run_forever()
@@ -166,7 +172,9 @@ def connect_console(session: SessionState):
     finally:
         if is_tty:
             # Always ensure the terminal is restored to its original state
-            termios.tcsetattr(fd, termios.TCSANOW, old_settings)
+            if termios and old_settings is not None and fd is not None:
+                termios.tcsetattr(fd, termios.TCSANOW, old_settings)
             # Restore the default signal handler for resize
-            signal.signal(signal.SIGWINCH, signal.SIG_DFL)
+            if hasattr(signal, "SIGWINCH"):
+                signal.signal(signal.SIGWINCH, signal.SIG_DFL)
         print("\r\nConnection closed.")

--- a/src/colab_cli/runtime.py
+++ b/src/colab_cli/runtime.py
@@ -115,7 +115,7 @@ class ColabRuntime:
                             },
                         )
                     else:
-                        self._kernel_client = jupyter_kernel_client.KernelClient(
+                        self._kernel_client = jupyter_kernel_client.JupyterKernelClient(
                             server_url=self.url,
                             token=self.token,
                             kernel_id=self.kernel_id,


### PR DESCRIPTION
Fixes #100

### Summary of Fixes

This PR adds native cross-platform support for Windows and resolves a runtime `AttributeError`:

1. **Windows Console Compatibility (`colab_cli/console.py`)**:
   - Wrapped `termios` and `tty` imports in a `try/except ImportError` block.
   - Added guards around `termios`, `tty`, `fileno()`, and `signal.SIGWINCH` calls to prevent `ModuleNotFoundError: No module named 'termios'` on Windows.

2. **Google Drive Auth `/dev/tty` Fallback (`colab_cli/commands/automation.py`)**:
   - Added a fallback for `open("/dev/tty")` on non-POSIX systems to use `sys.stdin.readline()`.

3. **`JupyterKernelClient` Fallback (`colab_cli/runtime.py`)**:
   - Fixed `AttributeError: module 'jupyter_kernel_client' has no attribute 'KernelClient'` in `ColabRuntime.kernel_client` by updating the fallback class name to `jupyter_kernel_client.JupyterKernelClient`.

### Testing Verification

Verified end-to-end on Windows 11 with PowerShell:
- Created sessions using `colab new --gpu T4 -s demo-session`
- Handled OAuth flow & Drive automation
- Executed Python code & GPU workloads (`nvidia-smi` on Tesla T4 runtime)
