### PR TITLE
fix: support PyPI jupyter-kernel-client>=1.0 (JupyterKernelClient rename)

### DIFF
--- a/src/colab_cli/runtime.py
+++ b/src/colab_cli/runtime.py
@@ -103,28 +103,32 @@ class ColabRuntime:
                         # WSSession (Session) expects 'session' for the ID
                         client_kwargs["session"] = self.session_id
 
+                    # Resolve the kernel client class across
+                    # jupyter-kernel-client variants:
+                    # - git (googlecolab fork): ColabKernelClient(proxy_token=...)
+                    # - PyPI <1.0: KernelClient(token=...)
+                    # - PyPI >=1.0: JupyterKernelClient(token=...)
+                    #   (KernelClient was renamed, breaking `colab exec` with
+                    #   AttributeError when installed from PyPI).
                     if hasattr(jupyter_kernel_client, "ColabKernelClient"):
-                        self._kernel_client = jupyter_kernel_client.ColabKernelClient(
-                            server_url=self.url,
-                            proxy_token=self.token,
-                            kernel_id=self.kernel_id,
-                            client_kwargs=client_kwargs,
-                            headers={
-                                "X-Colab-Client-Agent": "colab-cli",
-                                "X-Colab-Runtime-Proxy-Token": self.token,
-                            },
-                        )
+                        _ClientCls = jupyter_kernel_client.ColabKernelClient
+                        _token_kw = "proxy_token"
+                    elif hasattr(jupyter_kernel_client, "KernelClient"):
+                        _ClientCls = jupyter_kernel_client.KernelClient
+                        _token_kw = "token"
                     else:
-                        self._kernel_client = jupyter_kernel_client.KernelClient(
-                            server_url=self.url,
-                            token=self.token,
-                            kernel_id=self.kernel_id,
-                            client_kwargs=client_kwargs,
-                            headers={
-                                "X-Colab-Client-Agent": "colab-cli",
-                                "X-Colab-Runtime-Proxy-Token": self.token,
-                            },
-                        )
+                        _ClientCls = jupyter_kernel_client.JupyterKernelClient
+                        _token_kw = "token"
+                    self._kernel_client = _ClientCls(
+                        server_url=self.url,
+                        **{_token_kw: self.token},
+                        kernel_id=self.kernel_id,
+                        client_kwargs=client_kwargs,
+                        headers={
+                            "X-Colab-Client-Agent": "colab-cli",
+                            "X-Colab-Runtime-Proxy-Token": self.token,
+                        },
+                    )
                     # Force _own_kernel to False. This prevents jupyter-kernel-client
                     # from automatically deleting the kernel when the client is closed or deleted.
                     self._kernel_client._own_kernel = False

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -20,8 +20,15 @@ from colab_cli.runtime import ColabRuntime
 
 
 def test_colab_runtime_kernel_client():
-    target_attr = "ColabKernelClient" if hasattr(jupyter_kernel_client, "ColabKernelClient") else "KernelClient"
-    token_param_name = "proxy_token" if hasattr(jupyter_kernel_client, "ColabKernelClient") else "token"
+    if hasattr(jupyter_kernel_client, "ColabKernelClient"):
+        target_attr = "ColabKernelClient"
+        token_param_name = "proxy_token"
+    elif hasattr(jupyter_kernel_client, "KernelClient"):
+        target_attr = "KernelClient"
+        token_param_name = "token"
+    else:
+        target_attr = "JupyterKernelClient"
+        token_param_name = "token"
 
     with patch.object(jupyter_kernel_client, target_attr) as mock_kc_cls:
         mock_kc = mock_kc_cls.return_value
@@ -47,6 +54,51 @@ def test_colab_runtime_kernel_client():
         mock_kc_cls.assert_called_once_with(**expected_kwargs)
         mock_kc.start.assert_called_once()
         assert kc == mock_kc
+
+
+def test_colab_runtime_kernel_client_jupyterclient_fallback():
+    """PyPI jupyter-kernel-client>=1.0 renamed KernelClient to
+    JupyterKernelClient. Runtime must fall back to it instead of raising
+    AttributeError (breaks `colab exec` on `uv tool install google-colab-cli`)."""
+    import colab_cli.runtime as runtime_mod
+
+    real_colab = getattr(jupyter_kernel_client, "ColabKernelClient", None)
+    real_legacy = getattr(jupyter_kernel_client, "KernelClient", None)
+    had_colab = hasattr(jupyter_kernel_client, "ColabKernelClient")
+    had_legacy = hasattr(jupyter_kernel_client, "KernelClient")
+
+    if had_colab:
+        delattr(jupyter_kernel_client, "ColabKernelClient")
+    if had_legacy:
+        delattr(jupyter_kernel_client, "KernelClient")
+    try:
+        with patch.object(
+            jupyter_kernel_client, "JupyterKernelClient", create=True
+        ) as mock_kc_cls:
+            mock_kc = mock_kc_cls.return_value
+            runtime = ColabRuntime("http://url", "token123")
+            kc = runtime.kernel_client
+            mock_kc_cls.assert_called_once_with(
+                server_url="http://url",
+                token="token123",
+                kernel_id=None,
+                client_kwargs={
+                    "subprotocol": jupyter_kernel_client.JupyterSubprotocol.DEFAULT,
+                    "extra_params": {"colab-runtime-proxy-token": "token123"},
+                },
+                headers={
+                    "X-Colab-Client-Agent": "colab-cli",
+                    "X-Colab-Runtime-Proxy-Token": "token123",
+                },
+            )
+            mock_kc.start.assert_called_once()
+            assert kc == mock_kc
+    finally:
+        if had_colab:
+            jupyter_kernel_client.ColabKernelClient = real_colab
+        if had_legacy:
+            jupyter_kernel_client.KernelClient = real_legacy
+        assert runtime_mod  # keep import used for clarity
 
 
 def test_colab_runtime_execute_code():


### PR DESCRIPTION
## Problem

Installing from PyPI (`uv tool install google-colab-cli` / `pip install google-colab-cli`) resolves the unpinned `jupyter-kernel-client` dependency to 1.0.2, where `KernelClient` was renamed to `JupyterKernelClient`.

`colab exec` then fails on any session (auth + `colab status`/`colab ls` still work):

```
AttributeError: module 'jupyter_kernel_client' has no attribute 'KernelClient'
```

Full traceback originates at `src/colab_cli/runtime.py` in `ColabRuntime.kernel_client` (`jupyter_kernel_client.KernelClient(...)`).

Repro (CLI 0.6.0 + PyPI jupyter-kernel-client 1.0.2):
```bash
colab status   # OK - shows session, IDLE
colab ls       # OK
echo "print('hi')" | colab exec   # AttributeError above
```

## Fix

Resolve the client class across all known variants in `ColabRuntime.kernel_client`:

- `ColabKernelClient(proxy_token=...)` (git fork version)
- `KernelClient(token=...)` (PyPI <1.0)
- `JupyterKernelClient(token=...)` (PyPI >=1.0, fallback)

The `JupyterKernelClient` constructor is compatible (passes through to `KernelHttpManager` via `**kwargs`: `server_url`, `token`, `kernel_id`, `client_kwargs`, `headers`), verified live with `colab exec` after patching.

## Tests

- Updated `test_colab_runtime_kernel_client` to handle all three variants.
- Added `test_colab_runtime_kernel_client_jupyterclient_fallback` simulating PyPI>=1.0 (only `JupyterKernelClient` present).
- `uv run pytest tests/test_runtime.py -v`: 9 passed.
- `uv run ruff check` + `ruff format --check`: clean.
- Live: `echo "print('connection_test_ok')" | colab exec` → `connection_test_ok`.